### PR TITLE
Make divinity.* the canonical permission namespace

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/Perms.java
+++ b/src/main/java/studio/magemonkey/divinity/Perms.java
@@ -5,7 +5,7 @@ import studio.magemonkey.divinity.modules.api.socketing.ModuleSocket;
 
 public class Perms {
 
-    private static final String PREFIX = "quantumrpg.";
+    private static final String PREFIX = "divinity.";
 
     public static final String USER  = PREFIX + "user";
     public static final String ADMIN = PREFIX + "admin";

--- a/src/main/java/studio/magemonkey/divinity/Perms.java
+++ b/src/main/java/studio/magemonkey/divinity/Perms.java
@@ -1,13 +1,11 @@
 package studio.magemonkey.divinity;
 
-import org.bukkit.permissions.Permissible;
 import org.jetbrains.annotations.NotNull;
 import studio.magemonkey.divinity.modules.api.socketing.ModuleSocket;
 
 public class Perms {
 
-    private static final String PREFIX  = "quantumrpg.";
-    private static final String DIVINITY = "divinity.";
+    private static final String PREFIX = "quantumrpg.";
 
     public static final String USER  = PREFIX + "user";
     public static final String ADMIN = PREFIX + "admin";
@@ -99,21 +97,5 @@ public class Perms {
     @NotNull
     public static String getSocketGuiMerchant(@NotNull ModuleSocket<?> module) {
         return SOCKET_GUI_MERCHANT.replace("%module%", module.getId());
-    }
-
-    /**
-     * Checks whether the permissible has the given permission, accepting both
-     * the legacy {@code quantumrpg.*} namespace and the current {@code divinity.*}
-     * namespace as equivalent.
-     */
-    public static boolean has(@NotNull Permissible permissible, @NotNull String permission) {
-        if (permissible.hasPermission(permission)) return true;
-        if (permission.startsWith(PREFIX)) {
-            return permissible.hasPermission(DIVINITY + permission.substring(PREFIX.length()));
-        }
-        if (permission.startsWith(DIVINITY)) {
-            return permissible.hasPermission(PREFIX + permission.substring(DIVINITY.length()));
-        }
-        return false;
     }
 }

--- a/src/main/java/studio/magemonkey/divinity/modules/api/socketing/ModuleSocket.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/api/socketing/ModuleSocket.java
@@ -160,7 +160,7 @@ public abstract class ModuleSocket<I extends SocketItem> extends QModuleDrop<I> 
             @NotNull I mItem,
             @NotNull InventoryClickEvent e) {
 
-        if (!Perms.has(player, Perms.getSocketGuiUser(this))) {
+        if (!player.hasPermission(Perms.getSocketGuiUser(this))) {
             plugin.lang().Error_NoPerm.send(player);
             return false;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/api/socketing/merchant/MerchantCmd.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/api/socketing/merchant/MerchantCmd.java
@@ -40,7 +40,7 @@ public class MerchantCmd extends MCmd<ModuleSocket<?>> {
     @Override
     @NotNull
     public List<String> getTab(@NotNull Player player, int i, @NotNull String[] args) {
-        if (Perms.has(player, Perms.getSocketCmdMerchantOthers(this.module))) {
+        if (player.hasPermission(Perms.getSocketCmdMerchantOthers(this.module))) {
             if (i == 1) {
                 return PlayerUT.getPlayerNames();
             }
@@ -57,7 +57,7 @@ public class MerchantCmd extends MCmd<ModuleSocket<?>> {
             this.printUsage(sender);
             return;
         }
-        if (args.length > 1 && !Perms.has(sender, Perms.getSocketCmdMerchantOthers(this.module))) {
+        if (args.length > 1 && !sender.hasPermission(Perms.getSocketCmdMerchantOthers(this.module))) {
             this.errPerm(sender);
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/api/socketing/merchant/MerchantSocket.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/api/socketing/merchant/MerchantSocket.java
@@ -69,7 +69,7 @@ public class MerchantSocket implements Loadable {
     }
 
     public void openMerchantGUI(@NotNull Player player, boolean force) {
-        if (!force && !Perms.has(player, Perms.getSocketGuiMerchant(this.moduleSocket))) {
+        if (!force && !player.hasPermission(Perms.getSocketGuiMerchant(this.moduleSocket))) {
             plugin.lang().Error_NoPerm.send(player);
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClass.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClass.java
@@ -213,7 +213,7 @@ public class RPGClass extends LoadableItem {
         if (!this.isPermissionRequired()) return true;
 
         String node = Perms.CLASS_CLASS + "." + this.getId();
-        return Perms.has(player, node);
+        return player.hasPermission(node);
     }
 
     @NotNull

--- a/src/main/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClass.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClass.java
@@ -212,8 +212,12 @@ public class RPGClass extends LoadableItem {
     public boolean hasPermission(@NotNull Player player) {
         if (!this.isPermissionRequired()) return true;
 
-        String node = Perms.CLASS_CLASS + "." + this.getId();
-        return player.hasPermission(node);
+        // Class IDs are user-defined, so plugin.yml can't statically alias this
+        // node between namespaces the way it does for the fixed permission
+        // nodes elsewhere in the plugin.
+        String id = this.getId();
+        return player.hasPermission(Perms.CLASS_CLASS + "." + id)
+                || player.hasPermission("quantumrpg.classes.class." + id);
     }
 
     @NotNull

--- a/src/main/java/studio/magemonkey/divinity/modules/list/dismantle/DismantleManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/dismantle/DismantleManager.java
@@ -105,7 +105,7 @@ public class DismantleManager extends QModuleDrop<DismantleItem> {
     // METHODS
 
     public void openDismantleGUI(@NotNull Player player, boolean isForce) {
-        if (!isForce && !Perms.has(player, Perms.DISMANTLE_GUI)) {
+        if (!isForce && !player.hasPermission(Perms.DISMANTLE_GUI)) {
             plugin.lang().Error_NoPerm.send(player);
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/extractor/ExtractorManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/extractor/ExtractorManager.java
@@ -110,7 +110,7 @@ public class ExtractorManager extends QModuleDrop<ExtractorTool> {
             boolean force
     ) {
 
-        if (!force && !Perms.has(player, Perms.EXTRACTOR_GUI)) {
+        if (!force && !player.hasPermission(Perms.EXTRACTOR_GUI)) {
             plugin.lang().Error_NoPerm.send(player);
             return false;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/magicdust/MagicDustManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/magicdust/MagicDustManager.java
@@ -171,7 +171,7 @@ public class MagicDustManager extends QModuleDrop<MagicDust> {
     }
 
     public void openGUIPaid(@NotNull Player player, @Nullable ItemStack target, boolean force) {
-        if (!force && !Perms.has(player, Perms.MAGIC_DUST_GUI)) {
+        if (!force && !player.hasPermission(Perms.MAGIC_DUST_GUI)) {
             plugin.lang().Error_NoPerm.send(player);
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/repair/RepairManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/repair/RepairManager.java
@@ -177,7 +177,7 @@ public class RepairManager extends QModuleDrop<RepairItem> {
             @Nullable RepairType type,
             boolean isForce) {
 
-        if (!isForce && !Perms.has(player, Perms.REPAIR_GUI)) {
+        if (!isForce && !player.hasPermission(Perms.REPAIR_GUI)) {
             plugin.lang().Error_NoPerm.send(player);
             return false;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/sell/SellManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/sell/SellManager.java
@@ -74,7 +74,7 @@ public class SellManager extends QModule {
     }
 
     public void openSellGUI(@NotNull Player player, boolean isForce) {
-        if (!isForce && !Perms.has(player, Perms.SELL_GUI)) {
+        if (!isForce && !player.hasPermission(Perms.SELL_GUI)) {
             plugin.lang().Error_NoPerm.send(player);
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/soulbound/SoulboundManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/soulbound/SoulboundManager.java
@@ -210,7 +210,7 @@ public class SoulboundManager extends QModule {
             }
         } else {
             if (this.hasOwner(item)) {
-                if (!this.isOwner(item, p) && !Perms.has(p, Perms.BYPASS_REQ_USER_UNTRADEABLE)) {
+                if (!this.isOwner(item, p) && !p.hasPermission(Perms.BYPASS_REQ_USER_UNTRADEABLE)) {
                     e.setCancelled(true);
                     return;
                 }

--- a/src/main/java/studio/magemonkey/divinity/utils/ItemUtils.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/ItemUtils.java
@@ -33,7 +33,6 @@ import studio.magemonkey.divinity.modules.list.identify.IdentifyManager;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 import studio.magemonkey.divinity.stats.items.attributes.stats.DurabilityStat;
 import studio.magemonkey.divinity.stats.items.requirements.ItemRequirements;
-import studio.magemonkey.divinity.Perms;
 import studio.magemonkey.divinity.stats.items.requirements.api.UserRequirement;
 import studio.magemonkey.divinity.types.ItemGroup;
 import studio.magemonkey.divinity.types.ItemSubType;
@@ -63,7 +62,7 @@ public class ItemUtils {
 
         if (!Hooks.isNPC(player)) {
             for (UserRequirement<?> req : ItemRequirements.getUserRequirements()) {
-                if (!Perms.has(player, req.getBypassPermission()) && !req.canUse(player, item)) {
+                if (!player.hasPermission(req.getBypassPermission()) && !req.canUse(player, item)) {
                     if (msg) req.getDenyMessage(player, item)
                             .replace("%item%", ItemUT.getItemName(item))
                             .replace("%player%", player.getName())

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -49,60 +49,80 @@ permissions:
     description: User access
     default: true
 
-  divinity.bypass:
+  # Legacy aliases kept so servers granting the old quantumrpg.* nodes
+  # directly (instead of divinity.*) don't need to change anything.
+  quantumrpg.admin:
+    description: Legacy alias for divinity.admin.
+    default: op
+    children:
+      divinity.admin: true
+  quantumrpg.user:
+    description: Legacy alias for divinity.user.
+    default: true
+    children:
+      divinity.user: true
+
+  quantumrpg.bypass:
     description: Bypass all the plugin restrictions and requirements.
     default: op
     children:
-      divinity.bypass.requirement: true
-  divinity.bypass.requirement:
+      quantumrpg.bypass.requirement: true
+  quantumrpg.bypass.requirement:
     description: Bypass all item player requirements.
     default: op
     children:
-      quantumrpg.bypass.requirement: true
-      divinity.bypass.requirement.class: true
-      divinity.bypass.requirement.level: true
-      divinity.bypass.requirement.soulbound: true
-      divinity.bypass.requirement.untradeable: true
-  divinity.bypass.requirement.level:
+      divinity.bypass.requirement: true
+      quantumrpg.bypass.requirement.class: true
+      quantumrpg.bypass.requirement.level: true
+      quantumrpg.bypass.requirement.soulbound: true
+      quantumrpg.bypass.requirement.untradeable: true
+  quantumrpg.bypass.requirement.level:
     description: Bypass item player level requirement.
     default: op
     children:
-      quantumrpg.bypass.requirement.level: true
-  divinity.bypass.requirement.class:
+      divinity.bypass.requirement.level: true
+  quantumrpg.bypass.requirement.class:
     description: Bypass item player class requirement.
     default: op
     children:
-      quantumrpg.bypass.requirement.class: true
-  divinity.bypass.requirement.soulbound:
+      divinity.bypass.requirement.class: true
+  quantumrpg.bypass.requirement.soulbound:
     description: Bypass item player soulbound requirement.
     default: op
     children:
-      quantumrpg.bypass.requirement.soulbound: true
-  divinity.bypass.requirement.untradeable:
+      divinity.bypass.requirement.soulbound: true
+  quantumrpg.bypass.requirement.untradeable:
     description: Bypass item untradeable requirement.
     default: op
 
     children:
-      quantumrpg.bypass.requirement.untradeable: true
+      divinity.bypass.requirement.untradeable: true
   # Classes ----------------------------------------------------
-  divinity.classes:
+  quantumrpg.classes:
     description: Full access to Classes module.
     default: op
     children:
-      quantumrpg.classes: true
-      divinity.classes.cmd: true
-      divinity.classes.class.*: true
-  divinity.classes.cmd:
+      divinity.classes: true
+      quantumrpg.classes.cmd: true
+      quantumrpg.classes.class.*: true
+  quantumrpg.classes.cmd:
     description: Full access to Classes commands.
     default: op
     children:
-      divinity.classes.cmd.cast: true
-      divinity.classes.cmd.select: true
-      divinity.classes.cmd.skills: true
-      divinity.classes.cmd.stats: true
-      divinity.classes.cmd.aspects: true
-      divinity.classes.cmd.addexp: true
-      divinity.classes.cmd.addlevel: true
+      quantumrpg.classes.cmd.cast: true
+      quantumrpg.classes.cmd.select: true
+      quantumrpg.classes.cmd.skills: true
+      quantumrpg.classes.cmd.stats: true
+      quantumrpg.classes.cmd.aspects: true
+      quantumrpg.classes.cmd.addexp: true
+      quantumrpg.classes.cmd.addlevel: true
+      quantumrpg.classes.cmd.addskill: true
+      quantumrpg.classes.cmd.addaspectpoints: true
+      quantumrpg.classes.cmd.addskillpoints: true
+      quantumrpg.classes.cmd.setclass: true
+      quantumrpg.classes.cmd.reset: true
+      quantumrpg.classes.cmd.resetaspectpoints: true
+      quantumrpg.classes.cmd.resetskillpoints: true
       divinity.classes.cmd.addskill: true
       divinity.classes.cmd.addaspectpoints: true
       divinity.classes.cmd.addskillpoints: true
@@ -110,616 +130,516 @@ permissions:
       divinity.classes.cmd.reset: true
       divinity.classes.cmd.resetaspectpoints: true
       divinity.classes.cmd.resetskillpoints: true
-      quantumrpg.classes.cmd.addskill: true
-      quantumrpg.classes.cmd.addaspectpoints: true
-      quantumrpg.classes.cmd.addskillpoints: true
-      quantumrpg.classes.cmd.setclass: true
-      quantumrpg.classes.cmd.reset: true
-      quantumrpg.classes.cmd.resetaspectpoints: true
-      quantumrpg.classes.cmd.resetskillpoints: true
-  divinity.classes.cmd.cast:
-    description: Access to /class cast command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.cast: true
-  divinity.classes.cmd.select:
-    description: Access to /class select command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.select: true
-  divinity.classes.cmd.skills:
-    description: Access to /class skills command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.skills: true
-  divinity.classes.cmd.stats:
-    description: Access to /class stats command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.stats: true
-  divinity.classes.cmd.aspects:
-    description: Access to /class aspects command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.aspects: true
-  divinity.classes.cmd.addexp:
-    description: Access to /class addexp command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addexp: true
-  divinity.classes.cmd.addlevel:
-    description: Access to /class addlevel command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addlevel: true
-  divinity.classes.cmd.addskill:
-    description: Access to /class addskill command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addskill: true
-  divinity.classes.cmd.addaspectpoints:
-    description: Access to /class addaspectpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addaspectpoints: true
-  divinity.classes.cmd.addskillpoints:
-    description: Access to /class addskillpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addskillpoints: true
-  divinity.classes.cmd.setclass:
-    description: Access to /class setclass command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.setclass: true
-  divinity.classes.cmd.reset:
-    description: Access to /class reset command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.reset: true
-  divinity.classes.cmd.resetaspectpoints:
-    description: Access to /class resetaspectpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.resetaspectpoints: true
-  divinity.classes.cmd.resetskillpoints:
-    description: Access to /class resetskillpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.resetskillpoints: true
-  divinity.classes.class.*:
-    description: Access to all classes.
-    default: op
   quantumrpg.classes.cmd.cast:
     description: Access to /class cast command.
     default: op
+    children:
+      divinity.classes.cmd.cast: true
   quantumrpg.classes.cmd.select:
     description: Access to /class select command.
     default: true
+    children:
+      divinity.classes.cmd.select: true
   quantumrpg.classes.cmd.skills:
     description: Access to /class skills command.
     default: true
+    children:
+      divinity.classes.cmd.skills: true
   quantumrpg.classes.cmd.stats:
     description: Access to /class stats command.
     default: true
+    children:
+      divinity.classes.cmd.stats: true
   quantumrpg.classes.cmd.aspects:
     description: Access to /class aspects command.
     default: true
+    children:
+      divinity.classes.cmd.aspects: true
   quantumrpg.classes.cmd.addexp:
     description: Access to /class addexp command.
     default: op
-  quantumrpg.classes.cmd.addskillpoints:
-    description: Access to /class addskillpoints command.
-    default: op
-  quantumrpg.classes.cmd.addaspectpoints:
-    description: Access to /class addaspectpoints command.
-    default: op
+    children:
+      divinity.classes.cmd.addexp: true
   quantumrpg.classes.cmd.addlevel:
     description: Access to /class addlevel command.
     default: op
+    children:
+      divinity.classes.cmd.addlevel: true
+  quantumrpg.classes.cmd.addskill:
+    description: Access to /class addskill command.
+    default: op
+    children:
+      divinity.classes.cmd.addskill: true
+  quantumrpg.classes.cmd.addaspectpoints:
+    description: Access to /class addaspectpoints command.
+    default: op
+    children:
+      divinity.classes.cmd.addaspectpoints: true
+  quantumrpg.classes.cmd.addskillpoints:
+    description: Access to /class addskillpoints command.
+    default: op
+    children:
+      divinity.classes.cmd.addskillpoints: true
   quantumrpg.classes.cmd.setclass:
     description: Access to /class setclass command.
     default: op
+    children:
+      divinity.classes.cmd.setclass: true
   quantumrpg.classes.cmd.reset:
     description: Access to /class reset command.
     default: op
+    children:
+      divinity.classes.cmd.reset: true
   quantumrpg.classes.cmd.resetaspectpoints:
     description: Access to /class resetaspectpoints command.
     default: op
+    children:
+      divinity.classes.cmd.resetaspectpoints: true
   quantumrpg.classes.cmd.resetskillpoints:
     description: Access to /class resetskillpoints command.
     default: op
+    children:
+      divinity.classes.cmd.resetskillpoints: true
   quantumrpg.classes.class.*:
+    description: Access to all classes.
+    default: op
+  divinity.classes.cmd.cast:
+    description: Access to /class cast command.
+    default: op
+  divinity.classes.cmd.select:
+    description: Access to /class select command.
+    default: true
+  divinity.classes.cmd.skills:
+    description: Access to /class skills command.
+    default: true
+  divinity.classes.cmd.stats:
+    description: Access to /class stats command.
+    default: true
+  divinity.classes.cmd.aspects:
+    description: Access to /class aspects command.
+    default: true
+  divinity.classes.cmd.addexp:
+    description: Access to /class addexp command.
+    default: op
+  divinity.classes.cmd.addskillpoints:
+    description: Access to /class addskillpoints command.
+    default: op
+  divinity.classes.cmd.addaspectpoints:
+    description: Access to /class addaspectpoints command.
+    default: op
+  divinity.classes.cmd.addlevel:
+    description: Access to /class addlevel command.
+    default: op
+  divinity.classes.cmd.setclass:
+    description: Access to /class setclass command.
+    default: op
+  divinity.classes.cmd.reset:
+    description: Access to /class reset command.
+    default: op
+  divinity.classes.cmd.resetaspectpoints:
+    description: Access to /class resetaspectpoints command.
+    default: op
+  divinity.classes.cmd.resetskillpoints:
+    description: Access to /class resetskillpoints command.
+    default: op
+  divinity.classes.class.*:
     description: Access to all classes.
     default: op
 
   # Combat Log ----------------------------------------------------
-  divinity.combatlog:
-    description: Full access to Combat Log module.
-    default: op
-    children:
-      divinity.combatlog.cmd: true
-      quantumrpg.combatlog.cmd: true
-  divinity.combatlog.cmd:
-    description: Access to all Combat Log commands.
-    default: op
-    children:
-      divinity.combatlog.cmd.log: true
-      quantumrpg.combatlog.cmd.log: true
-  divinity.combatlog.cmd.log:
-    description: Access to /combatlog log command.
-    default: true
-    children:
-      quantumrpg.combatlog.cmd.log: true
   quantumrpg.combatlog:
     description: Full access to Combat Log module.
     default: op
     children:
       quantumrpg.combatlog.cmd: true
+      divinity.combatlog.cmd: true
   quantumrpg.combatlog.cmd:
     description: Access to all Combat Log commands.
     default: op
     children:
       quantumrpg.combatlog.cmd.log: true
+      divinity.combatlog.cmd.log: true
   quantumrpg.combatlog.cmd.log:
+    description: Access to /combatlog log command.
+    default: true
+    children:
+      divinity.combatlog.cmd.log: true
+  divinity.combatlog:
+    description: Full access to Combat Log module.
+    default: op
+    children:
+      divinity.combatlog.cmd: true
+  divinity.combatlog.cmd:
+    description: Access to all Combat Log commands.
+    default: op
+    children:
+      divinity.combatlog.cmd.log: true
+  divinity.combatlog.cmd.log:
     description: Access to /combatlog log command.
     default: true
 
   # Dismantle ----------------------------------------------------
-  divinity.dismantle:
-    description: Full access to the Dismantle module.
-    default: op
-    children:
-      divinity.dismantle.cmd: true
-      divinity.dismantle.gui: true
-      quantumrpg.dismantle.cmd: true
-      quantumrpg.dismantle.gui: true
-  divinity.dismantle.cmd:
-    description: Access to Dismantle commands.
-    default: op
-    children:
-      divinity.dismantle.cmd.open: true
-      quantumrpg.dismantle.cmd.open: true
-  divinity.dismantle.cmd.open:
-    description: Access to /dismantle open command.
-    default: op
-    children:
-      quantumrpg.dismantle.cmd.open: true
-  divinity.dismantle.gui:
-    description: Access to Dismantle GUI.
-    default: op
-    children:
-      quantumrpg.dismantle.gui: true
   quantumrpg.dismantle:
     description: Full access to the Dismantle module.
     default: op
     children:
       quantumrpg.dismantle.cmd: true
       quantumrpg.dismantle.gui: true
+      divinity.dismantle.cmd: true
+      divinity.dismantle.gui: true
   quantumrpg.dismantle.cmd:
     description: Access to Dismantle commands.
     default: op
     children:
       quantumrpg.dismantle.cmd.open: true
+      divinity.dismantle.cmd.open: true
+  quantumrpg.dismantle.cmd.open:
+    description: Access to /dismantle open command.
+    default: op
+    children:
+      divinity.dismantle.cmd.open: true
   quantumrpg.dismantle.gui:
+    description: Access to Dismantle GUI.
+    default: op
+    children:
+      divinity.dismantle.gui: true
+  divinity.dismantle:
+    description: Full access to the Dismantle module.
+    default: op
+    children:
+      divinity.dismantle.cmd: true
+      divinity.dismantle.gui: true
+  divinity.dismantle.cmd:
+    description: Access to Dismantle commands.
+    default: op
+    children:
+      divinity.dismantle.cmd.open: true
+  divinity.dismantle.gui:
     description: Access to Dismantle GUI.
     default: op
 
   # Essences ----------------------------------------------------
-  divinity.essences:
-    description: Full access to Essences module.
-    default: op
-    children:
-      divinity.essences.cmd: true
-      divinity.essences.gui: true
-      quantumrpg.essences.cmd: true
-      quantumrpg.essences.gui: true
-  divinity.essences.cmd:
-    description: Access to all Essences commands.
-    default: op
-    children:
-      divinity.essences.cmd.merchant: true
-      divinity.essences.cmd.merchant.others: true
-      quantumrpg.essences.cmd.merchant: true
-      quantumrpg.essences.cmd.merchant.others: true
-  divinity.essences.cmd.merchant:
-    description: Access to /essences merchant command.
-    default: op
-    children:
-      quantumrpg.essences.cmd.merchant: true
-  divinity.essences.cmd.merchant.others:
-    description: Access to /essences merchant [player] command.
-    default: op
-    children:
-      quantumrpg.essences.cmd.merchant.others: true
-  divinity.essences.gui:
-    description: Access to all Essences GUIs.
-    default: op
-    children:
-      divinity.essences.gui.user: true
-      divinity.essences.gui.merchant: true
-      quantumrpg.essences.gui.user: true
-      quantumrpg.essences.gui.merchant: true
-  divinity.essences.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      quantumrpg.essences.gui.user: true
-  divinity.essences.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      quantumrpg.essences.gui.merchant: true
   quantumrpg.essences:
     description: Full access to Essences module.
     default: op
     children:
       quantumrpg.essences.cmd: true
       quantumrpg.essences.gui: true
-
+      divinity.essences.cmd: true
+      divinity.essences.gui: true
   quantumrpg.essences.cmd:
     description: Access to all Essences commands.
     default: op
     children:
       quantumrpg.essences.cmd.merchant: true
       quantumrpg.essences.cmd.merchant.others: true
+      divinity.essences.cmd.merchant: true
+      divinity.essences.cmd.merchant.others: true
   quantumrpg.essences.cmd.merchant:
     description: Access to /essences merchant command.
     default: op
+    children:
+      divinity.essences.cmd.merchant: true
   quantumrpg.essences.cmd.merchant.others:
     description: Access to /essences merchant [player] command.
     default: op
-
+    children:
+      divinity.essences.cmd.merchant.others: true
   quantumrpg.essences.gui:
     description: Access to all Essences GUIs.
     default: op
     children:
       quantumrpg.essences.gui.user: true
       quantumrpg.essences.gui.merchant: true
+      divinity.essences.gui.user: true
+      divinity.essences.gui.merchant: true
   quantumrpg.essences.gui.user:
     description: Access to Default Socketing GUI.
     default: op
+    children:
+      divinity.essences.gui.user: true
   quantumrpg.essences.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      divinity.essences.gui.merchant: true
+  divinity.essences:
+    description: Full access to Essences module.
+    default: op
+    children:
+      divinity.essences.cmd: true
+      divinity.essences.gui: true
+
+  divinity.essences.cmd:
+    description: Access to all Essences commands.
+    default: op
+    children:
+      divinity.essences.cmd.merchant: true
+      divinity.essences.cmd.merchant.others: true
+  divinity.essences.cmd.merchant:
+    description: Access to /essences merchant command.
+    default: op
+  divinity.essences.cmd.merchant.others:
+    description: Access to /essences merchant [player] command.
+    default: op
+
+  divinity.essences.gui:
+    description: Access to all Essences GUIs.
+    default: op
+    children:
+      divinity.essences.gui.user: true
+      divinity.essences.gui.merchant: true
+  divinity.essences.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+  divinity.essences.gui.merchant:
     description: Access to Merchant Socketing GUI.
     default: op
 
   # Extractor ----------------------------------------------------
-  divinity.extractor:
-    description: Full access to Extractor module.
-    default: op
-    children:
-      divinity.extractor.cmd: true
-      divinity.extractor.gui: true
-      quantumrpg.extractor.cmd: true
-      quantumrpg.extractor.gui: true
-  divinity.extractor.cmd:
-    description: Access to all Extractor commands.
-    default: op
-    children:
-      divinity.extractor.cmd.open: true
-      quantumrpg.extractor.cmd.open: true
-  divinity.extractor.cmd.open:
-    description: Access to /extractor open command.
-    default: op
-    children:
-      quantumrpg.extractor.cmd.open: true
-  divinity.extractor.gui:
-    description: Access Extractor GUI.
-    default: op
-    children:
-      quantumrpg.extractor.gui: true
   quantumrpg.extractor:
     description: Full access to Extractor module.
     default: op
     children:
       quantumrpg.extractor.cmd: true
       quantumrpg.extractor.gui: true
+      divinity.extractor.cmd: true
+      divinity.extractor.gui: true
   quantumrpg.extractor.cmd:
     description: Access to all Extractor commands.
     default: op
     children:
       quantumrpg.extractor.cmd.open: true
+      divinity.extractor.cmd.open: true
   quantumrpg.extractor.cmd.open:
     description: Access to /extractor open command.
     default: op
+    children:
+      divinity.extractor.cmd.open: true
   quantumrpg.extractor.gui:
+    description: Access Extractor GUI.
+    default: op
+    children:
+      divinity.extractor.gui: true
+  divinity.extractor:
+    description: Full access to Extractor module.
+    default: op
+    children:
+      divinity.extractor.cmd: true
+      divinity.extractor.gui: true
+  divinity.extractor.cmd:
+    description: Access to all Extractor commands.
+    default: op
+    children:
+      divinity.extractor.cmd.open: true
+  divinity.extractor.cmd.open:
+    description: Access to /extractor open command.
+    default: op
+  divinity.extractor.gui:
     description: Access Extractor GUI.
     default: op
 
   # Fortify ----------------------------------------------------
-  divinity.fortify:
-    description: Full access to Fortify module.
-    default: op
-    children:
-      divinity.fortify.cmd: true
-      quantumrpg.fortify.cmd: true
-  divinity.fortify.cmd:
-    description: Access to all Fortify commands.
-    default: op
-    children:
-      divinity.fortify.cmd.fortify: true
-      divinity.fortify.cmd.unfortify: true
-      quantumrpg.fortify.cmd.fortify: true
-      quantumrpg.fortify.cmd.unfortify: true
-  divinity.fortify.cmd.fortify:
-    description: Access to /fortify fortify command.
-    default: op
-    children:
-      quantumrpg.fortify.cmd.fortify: true
-  divinity.fortify.cmd.unfortify:
-    description: Access to /fortify unfortify command.
-    default: op
-    children:
-      quantumrpg.fortify.cmd.unfortify: true
   quantumrpg.fortify:
     description: Full access to Fortify module.
     default: op
     children:
       quantumrpg.fortify.cmd: true
+      divinity.fortify.cmd: true
   quantumrpg.fortify.cmd:
     description: Access to all Fortify commands.
     default: op
     children:
       quantumrpg.fortify.cmd.fortify: true
       quantumrpg.fortify.cmd.unfortify: true
+      divinity.fortify.cmd.fortify: true
+      divinity.fortify.cmd.unfortify: true
   quantumrpg.fortify.cmd.fortify:
     description: Access to /fortify fortify command.
     default: op
+    children:
+      divinity.fortify.cmd.fortify: true
   quantumrpg.fortify.cmd.unfortify:
+    description: Access to /fortify unfortify command.
+    default: op
+    children:
+      divinity.fortify.cmd.unfortify: true
+  divinity.fortify:
+    description: Full access to Fortify module.
+    default: op
+    children:
+      divinity.fortify.cmd: true
+  divinity.fortify.cmd:
+    description: Access to all Fortify commands.
+    default: op
+    children:
+      divinity.fortify.cmd.fortify: true
+      divinity.fortify.cmd.unfortify: true
+  divinity.fortify.cmd.fortify:
+    description: Access to /fortify fortify command.
+    default: op
+  divinity.fortify.cmd.unfortify:
     description: Access to /fortify unfortify command.
     default: op
 
   # Gems ----------------------------------------------------
-  divinity.gems:
-    description: Full access to Gems module.
-    default: op
-    children:
-      divinity.gems.cmd: true
-      divinity.gems.gui: true
-      quantumrpg.gems.cmd: true
-      quantumrpg.gems.gui: true
-  divinity.gems.cmd:
-    description: Access to all Gems commands.
-    default: op
-    children:
-      divinity.gems.cmd.merchant: true
-      divinity.gems.cmd.merchant.others: true
-      quantumrpg.gems.cmd.merchant: true
-      quantumrpg.gems.cmd.merchant.others: true
-  divinity.gems.cmd.merchant:
-    description: Access to /gems merchant command.
-    default: op
-    children:
-      quantumrpg.gems.cmd.merchant: true
-  divinity.gems.cmd.merchant.others:
-    description: Access to /gems merchant [player] command.
-    default: op
-    children:
-      quantumrpg.gems.cmd.merchant.others: true
-  divinity.gems.gui:
-    description: Access to all Gems GUIs.
-    default: op
-    children:
-      divinity.gems.gui.user: true
-      divinity.gems.gui.merchant: true
-      quantumrpg.gems.gui.user: true
-      quantumrpg.gems.gui.merchant: true
-  divinity.gems.gui.user:
-    description: Access to user socketing GUI.
-    default: op
-    children:
-      quantumrpg.gems.gui.user: true
-  divinity.gems.gui.merchant:
-    description: Access to Merchant socketing GUI.
-    default: op
-    children:
-      quantumrpg.gems.gui.merchant: true
   quantumrpg.gems:
     description: Full access to Gems module.
     default: op
     children:
       quantumrpg.gems.cmd: true
       quantumrpg.gems.gui: true
+      divinity.gems.cmd: true
+      divinity.gems.gui: true
   quantumrpg.gems.cmd:
     description: Access to all Gems commands.
     default: op
     children:
       quantumrpg.gems.cmd.merchant: true
       quantumrpg.gems.cmd.merchant.others: true
+      divinity.gems.cmd.merchant: true
+      divinity.gems.cmd.merchant.others: true
   quantumrpg.gems.cmd.merchant:
     description: Access to /gems merchant command.
     default: op
+    children:
+      divinity.gems.cmd.merchant: true
   quantumrpg.gems.cmd.merchant.others:
     description: Access to /gems merchant [player] command.
     default: op
+    children:
+      divinity.gems.cmd.merchant.others: true
   quantumrpg.gems.gui:
     description: Access to all Gems GUIs.
     default: op
     children:
       quantumrpg.gems.gui.user: true
       quantumrpg.gems.gui.merchant: true
+      divinity.gems.gui.user: true
+      divinity.gems.gui.merchant: true
   quantumrpg.gems.gui.user:
+    description: Access to user socketing GUI.
+    default: op
+    children:
+      divinity.gems.gui.user: true
+  quantumrpg.gems.gui.merchant:
+    description: Access to Merchant socketing GUI.
+    default: op
+    children:
+      divinity.gems.gui.merchant: true
+  divinity.gems:
+    description: Full access to Gems module.
+    default: op
+    children:
+      divinity.gems.cmd: true
+      divinity.gems.gui: true
+  divinity.gems.cmd:
+    description: Access to all Gems commands.
+    default: op
+    children:
+      divinity.gems.cmd.merchant: true
+      divinity.gems.cmd.merchant.others: true
+  divinity.gems.cmd.merchant:
+    description: Access to /gems merchant command.
+    default: op
+  divinity.gems.cmd.merchant.others:
+    description: Access to /gems merchant [player] command.
+    default: op
+  divinity.gems.gui:
+    description: Access to all Gems GUIs.
+    default: op
+    children:
+      divinity.gems.gui.user: true
+      divinity.gems.gui.merchant: true
+  divinity.gems.gui.user:
     description: Access to user GUI.
     default: op
-  quantumrpg.gems.gui.merchant:
+  divinity.gems.gui.merchant:
     description: Access to Merchant GUI.
     default: op
 
   # Identify ----------------------------------------------------
-  divinity.identify:
-    description: Full access to Identify module.
-    default: op
-    children:
-      divinity.identify.cmd: true
-      quantumrpg.identify.cmd: true
-  divinity.identify.cmd:
-    description: Access to all Identify commands.
-    default: op
-    children:
-      divinity.identify.cmd.identify: true
-      quantumrpg.identify.cmd.identify: true
-  divinity.identify.cmd.identify:
-    description: Access to /identify identify command.
-    default: op
-    children:
-      quantumrpg.identify.cmd.identify: true
   quantumrpg.identify:
     description: Full access to Identify module.
     default: op
     children:
       quantumrpg.identify.cmd: true
+      divinity.identify.cmd: true
   quantumrpg.identify.cmd:
     description: Access to all Identify commands.
     default: op
     children:
       quantumrpg.identify.cmd.identify: true
+      divinity.identify.cmd.identify: true
   quantumrpg.identify.cmd.identify:
+    description: Access to /identify identify command.
+    default: op
+    children:
+      divinity.identify.cmd.identify: true
+  divinity.identify:
+    description: Full access to Identify module.
+    default: op
+    children:
+      divinity.identify.cmd: true
+  divinity.identify.cmd:
+    description: Access to all Identify commands.
+    default: op
+    children:
+      divinity.identify.cmd.identify: true
+  divinity.identify.cmd.identify:
     description: Access to /identify identify command.
     default: op
 
   # Magic Dust ----------------------------------------------------
-  divinity.magicdust:
-    description: Full access to Magic Dust module.
-    default: op
-    children:
-      divinity.magicdust.cmd: true
-      divinity.magicdust.gui: true
-      quantumrpg.magicdust.cmd: true
-      quantumrpg.magicdust.gui: true
-  divinity.magicdust.cmd:
-    description: Full access to Magic Dust commands.
-    default: op
-    children:
-      divinity.magicdust.cmd.open: true
-      quantumrpg.magicdust.cmd.open: true
-  divinity.magicdust.cmd.open:
-    description: Allows to use /magicdust open command.
-    default: op
-    children:
-      quantumrpg.magicdust.cmd.open: true
-  divinity.magicdust.gui:
-    description: Allows to use Magic Dust GUI.
-    default: op
-    children:
-      quantumrpg.magicdust.gui: true
   quantumrpg.magicdust:
     description: Full access to Magic Dust module.
     default: op
     children:
       quantumrpg.magicdust.cmd: true
       quantumrpg.magicdust.gui: true
+      divinity.magicdust.cmd: true
+      divinity.magicdust.gui: true
   quantumrpg.magicdust.cmd:
     description: Full access to Magic Dust commands.
     default: op
     children:
       quantumrpg.magicdust.cmd.open: true
+      divinity.magicdust.cmd.open: true
   quantumrpg.magicdust.cmd.open:
     description: Allows to use /magicdust open command.
     default: op
+    children:
+      divinity.magicdust.cmd.open: true
   quantumrpg.magicdust.gui:
+    description: Allows to use Magic Dust GUI.
+    default: op
+    children:
+      divinity.magicdust.gui: true
+  divinity.magicdust:
+    description: Full access to Magic Dust module.
+    default: op
+    children:
+      divinity.magicdust.cmd: true
+      divinity.magicdust.gui: true
+  divinity.magicdust.cmd:
+    description: Full access to Magic Dust commands.
+    default: op
+    children:
+      divinity.magicdust.cmd.open: true
+  divinity.magicdust.cmd.open:
+    description: Allows to use /magicdust open command.
+    default: op
+  divinity.magicdust.gui:
     description: Allows to use Magic Dust GUI.
     default: op
 
   # Party ----------------------------------------------------
-  divinity.party:
-    description: Access to Party module.
-    default: true
-    children:
-      divinity.party.cmd: true
-      quantumrpg.party.cmd: true
-  divinity.party.cmd:
-    description: Access to Party commands.
-    default: op
-    children:
-      divinity.party.cmd.chat: true
-      divinity.party.cmd.create: true
-      divinity.party.cmd.disband: true
-      divinity.party.cmd.drop: true
-      divinity.party.cmd.exp: true
-      divinity.party.cmd.invite: true
-      divinity.party.cmd.join: true
-      divinity.party.cmd.kick: true
-      divinity.party.cmd.leave: true
-      divinity.party.cmd.menu: true
-      divinity.party.cmd.roll: true
-      divinity.party.cmd.tp: true
-      quantumrpg.party.cmd.chat: true
-      quantumrpg.party.cmd.create: true
-      quantumrpg.party.cmd.disband: true
-      quantumrpg.party.cmd.drop: true
-      quantumrpg.party.cmd.exp: true
-      quantumrpg.party.cmd.invite: true
-      quantumrpg.party.cmd.join: true
-      quantumrpg.party.cmd.kick: true
-      quantumrpg.party.cmd.leave: true
-      quantumrpg.party.cmd.menu: true
-      quantumrpg.party.cmd.roll: true
-      quantumrpg.party.cmd.tp: true
-  divinity.party.cmd.chat:
-    description: Access to /party chat command.
-    default: true
-    children:
-      quantumrpg.party.cmd.chat: true
-  divinity.party.cmd.create:
-    description: Access to /party create command.
-    default: true
-    children:
-      quantumrpg.party.cmd.create: true
-  divinity.party.cmd.disband:
-    description: Access to /party disband command.
-    default: true
-    children:
-      quantumrpg.party.cmd.disband: true
-  divinity.party.cmd.drop:
-    description: Access to /party drop command.
-    default: true
-    children:
-      quantumrpg.party.cmd.drop: true
-  divinity.party.cmd.exp:
-    description: Access to /party exp command.
-    default: true
-    children:
-      quantumrpg.party.cmd.exp: true
-  divinity.party.cmd.invite:
-    description: Access to /party invite command.
-    default: true
-    children:
-      quantumrpg.party.cmd.invite: true
-  divinity.party.cmd.join:
-    description: Access to /party join command.
-    default: true
-    children:
-      quantumrpg.party.cmd.join: true
-  divinity.party.cmd.kick:
-    description: Access to /party kick command.
-    default: true
-    children:
-      quantumrpg.party.cmd.kick: true
-  divinity.party.cmd.leave:
-    description: Access to /party leave command.
-    default: true
-    children:
-      quantumrpg.party.cmd.leave: true
-  divinity.party.cmd.menu:
-    description: Access to /party menu command.
-    default: true
-    children:
-      quantumrpg.party.cmd.menu: true
-  divinity.party.cmd.roll:
-    description: Access to /party roll command.
-    default: true
-    children:
-      quantumrpg.party.cmd.roll: true
-  divinity.party.cmd.tp:
-    description: Access to /party tp command.
-    default: true
-    children:
-      quantumrpg.party.cmd.tp: true
   quantumrpg.party:
     description: Access to Party module.
     default: true
     children:
       quantumrpg.party.cmd: true
+      divinity.party.cmd: true
   quantumrpg.party.cmd:
     description: Access to Party commands.
     default: op
@@ -736,271 +656,364 @@ permissions:
       quantumrpg.party.cmd.menu: true
       quantumrpg.party.cmd.roll: true
       quantumrpg.party.cmd.tp: true
+      divinity.party.cmd.chat: true
+      divinity.party.cmd.create: true
+      divinity.party.cmd.disband: true
+      divinity.party.cmd.drop: true
+      divinity.party.cmd.exp: true
+      divinity.party.cmd.invite: true
+      divinity.party.cmd.join: true
+      divinity.party.cmd.kick: true
+      divinity.party.cmd.leave: true
+      divinity.party.cmd.menu: true
+      divinity.party.cmd.roll: true
+      divinity.party.cmd.tp: true
   quantumrpg.party.cmd.chat:
     description: Access to /party chat command.
     default: true
+    children:
+      divinity.party.cmd.chat: true
   quantumrpg.party.cmd.create:
     description: Access to /party create command.
     default: true
+    children:
+      divinity.party.cmd.create: true
   quantumrpg.party.cmd.disband:
     description: Access to /party disband command.
     default: true
+    children:
+      divinity.party.cmd.disband: true
   quantumrpg.party.cmd.drop:
     description: Access to /party drop command.
     default: true
+    children:
+      divinity.party.cmd.drop: true
   quantumrpg.party.cmd.exp:
     description: Access to /party exp command.
     default: true
+    children:
+      divinity.party.cmd.exp: true
   quantumrpg.party.cmd.invite:
     description: Access to /party invite command.
     default: true
+    children:
+      divinity.party.cmd.invite: true
   quantumrpg.party.cmd.join:
     description: Access to /party join command.
     default: true
+    children:
+      divinity.party.cmd.join: true
   quantumrpg.party.cmd.kick:
     description: Access to /party kick command.
     default: true
+    children:
+      divinity.party.cmd.kick: true
   quantumrpg.party.cmd.leave:
     description: Access to /party leave command.
     default: true
+    children:
+      divinity.party.cmd.leave: true
   quantumrpg.party.cmd.menu:
     description: Access to /party menu command.
     default: true
+    children:
+      divinity.party.cmd.menu: true
   quantumrpg.party.cmd.roll:
     description: Access to /party roll command.
     default: true
+    children:
+      divinity.party.cmd.roll: true
   quantumrpg.party.cmd.tp:
+    description: Access to /party tp command.
+    default: true
+    children:
+      divinity.party.cmd.tp: true
+  divinity.party:
+    description: Access to Party module.
+    default: true
+    children:
+      divinity.party.cmd: true
+  divinity.party.cmd:
+    description: Access to Party commands.
+    default: op
+    children:
+      divinity.party.cmd.chat: true
+      divinity.party.cmd.create: true
+      divinity.party.cmd.disband: true
+      divinity.party.cmd.drop: true
+      divinity.party.cmd.exp: true
+      divinity.party.cmd.invite: true
+      divinity.party.cmd.join: true
+      divinity.party.cmd.kick: true
+      divinity.party.cmd.leave: true
+      divinity.party.cmd.menu: true
+      divinity.party.cmd.roll: true
+      divinity.party.cmd.tp: true
+  divinity.party.cmd.chat:
+    description: Access to /party chat command.
+    default: true
+  divinity.party.cmd.create:
+    description: Access to /party create command.
+    default: true
+  divinity.party.cmd.disband:
+    description: Access to /party disband command.
+    default: true
+  divinity.party.cmd.drop:
+    description: Access to /party drop command.
+    default: true
+  divinity.party.cmd.exp:
+    description: Access to /party exp command.
+    default: true
+  divinity.party.cmd.invite:
+    description: Access to /party invite command.
+    default: true
+  divinity.party.cmd.join:
+    description: Access to /party join command.
+    default: true
+  divinity.party.cmd.kick:
+    description: Access to /party kick command.
+    default: true
+  divinity.party.cmd.leave:
+    description: Access to /party leave command.
+    default: true
+  divinity.party.cmd.menu:
+    description: Access to /party menu command.
+    default: true
+  divinity.party.cmd.roll:
+    description: Access to /party roll command.
+    default: true
+  divinity.party.cmd.tp:
     description: Access to /party tp command.
     default: true
 
   # Refine ----------------------------------------------------
-  divinity.refine:
-    description: Access to Refine module.
-    default: op
-    children:
-      divinity.refine.cmd: true
-      quantumrpg.refine.cmd: true
-  divinity.refine.cmd:
-    description: Access to Refine commands.
-    default: op
-    children:
-      divinity.refine.cmd.refine: true
-      divinity.refine.cmd.downgrade: true
-      quantumrpg.refine.cmd.refine: true
-      quantumrpg.refine.cmd.downgrade: true
-  divinity.refine.cmd.refine:
-    description: Access to /refine refine command.
-    default: op
-    children:
-      quantumrpg.refine.cmd.refine: true
-  divinity.refine.cmd.downgrade:
-    description: Access to /refine downgrade command.
-    default: op
-    children:
-      quantumrpg.refine.cmd.downgrade: true
   quantumrpg.refine:
     description: Access to Refine module.
     default: op
     children:
       quantumrpg.refine.cmd: true
+      divinity.refine.cmd: true
   quantumrpg.refine.cmd:
     description: Access to Refine commands.
     default: op
     children:
       quantumrpg.refine.cmd.refine: true
       quantumrpg.refine.cmd.downgrade: true
+      divinity.refine.cmd.refine: true
+      divinity.refine.cmd.downgrade: true
+  quantumrpg.refine.cmd.refine:
+    description: Access to /refine refine command.
+    default: op
+    children:
+      divinity.refine.cmd.refine: true
+  quantumrpg.refine.cmd.downgrade:
+    description: Access to /refine downgrade command.
+    default: op
+    children:
+      divinity.refine.cmd.downgrade: true
+  divinity.refine:
+    description: Access to Refine module.
+    default: op
+    children:
+      divinity.refine.cmd: true
+  divinity.refine.cmd:
+    description: Access to Refine commands.
+    default: op
+    children:
+      divinity.refine.cmd.refine: true
+      divinity.refine.cmd.downgrade: true
 
   # Repair ----------------------------------------------------
-  divinity.repair:
-    description: Access to Repair module.
-    default: op
-    children:
-      divinity.repair.cmd: true
-      divinity.repair.gui: true
-      quantumrpg.repair.cmd: true
-      quantumrpg.repair.gui: true
-  divinity.repair.cmd:
-    description: Access to Repair commands.
-    default: op
-    children:
-      divinity.repair.cmd.open: true
-      quantumrpg.repair.cmd.open: true
-  divinity.repair.cmd.open:
-    description: Access to /repair open command.
-    default: op
-    children:
-      quantumrpg.repair.cmd.open: true
-  divinity.repair.gui:
-    description: Access to Repair GUI.
-    default: op
-    children:
-      quantumrpg.repair.gui: true
   quantumrpg.repair:
     description: Access to Repair module.
     default: op
     children:
       quantumrpg.repair.cmd: true
       quantumrpg.repair.gui: true
+      divinity.repair.cmd: true
+      divinity.repair.gui: true
   quantumrpg.repair.cmd:
     description: Access to Repair commands.
     default: op
     children:
       quantumrpg.repair.cmd.open: true
+      divinity.repair.cmd.open: true
+  quantumrpg.repair.cmd.open:
+    description: Access to /repair open command.
+    default: op
+    children:
+      divinity.repair.cmd.open: true
   quantumrpg.repair.gui:
+    description: Access to Repair GUI.
+    default: op
+    children:
+      divinity.repair.gui: true
+  divinity.repair:
+    description: Access to Repair module.
+    default: op
+    children:
+      divinity.repair.cmd: true
+      divinity.repair.gui: true
+  divinity.repair.cmd:
+    description: Access to Repair commands.
+    default: op
+    children:
+      divinity.repair.cmd.open: true
+  divinity.repair.gui:
     description: Access to Repair GUI.
     default: op
 
   # Runes ----------------------------------------------------
-  divinity.runes:
-    description: Full access to Runes module.
-    default: op
-    children:
-      divinity.runes.cmd: true
-      divinity.runes.gui: true
-      quantumrpg.runes.cmd: true
-      quantumrpg.runes.gui: true
-  divinity.runes.cmd:
-    description: Access to all Runes commands.
-    default: op
-    children:
-      divinity.runes.cmd.merchant: true
-      divinity.runes.cmd.merchant.others: true
-      quantumrpg.runes.cmd.merchant: true
-      quantumrpg.runes.cmd.merchant.others: true
-  divinity.runes.cmd.merchant:
-    description: Access to /runes merchant command.
-    default: op
-    children:
-      quantumrpg.runes.cmd.merchant: true
-  divinity.runes.cmd.merchant.others:
-    description: Access to /runes merchant [player] command.
-    default: op
-    children:
-      quantumrpg.runes.cmd.merchant.others: true
-  divinity.runes.gui:
-    description: Access to all Runes GUIs.
-    default: op
-    children:
-      divinity.runes.gui.user: true
-      divinity.runes.gui.merchant: true
-      quantumrpg.runes.gui.user: true
-      quantumrpg.runes.gui.merchant: true
-  divinity.runes.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      quantumrpg.runes.gui.user: true
-  divinity.runes.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      quantumrpg.runes.gui.merchant: true
   quantumrpg.runes:
     description: Full access to Runes module.
     default: op
     children:
       quantumrpg.runes.cmd: true
       quantumrpg.runes.gui: true
-
+      divinity.runes.cmd: true
+      divinity.runes.gui: true
   quantumrpg.runes.cmd:
     description: Access to all Runes commands.
     default: op
     children:
       quantumrpg.runes.cmd.merchant: true
       quantumrpg.runes.cmd.merchant.others: true
+      divinity.runes.cmd.merchant: true
+      divinity.runes.cmd.merchant.others: true
   quantumrpg.runes.cmd.merchant:
     description: Access to /runes merchant command.
     default: op
+    children:
+      divinity.runes.cmd.merchant: true
   quantumrpg.runes.cmd.merchant.others:
     description: Access to /runes merchant [player] command.
     default: op
-
+    children:
+      divinity.runes.cmd.merchant.others: true
   quantumrpg.runes.gui:
     description: Access to all Runes GUIs.
     default: op
     children:
       quantumrpg.runes.gui.user: true
       quantumrpg.runes.gui.merchant: true
+      divinity.runes.gui.user: true
+      divinity.runes.gui.merchant: true
   quantumrpg.runes.gui.user:
     description: Access to Default Socketing GUI.
     default: op
+    children:
+      divinity.runes.gui.user: true
   quantumrpg.runes.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      divinity.runes.gui.merchant: true
+  divinity.runes:
+    description: Full access to Runes module.
+    default: op
+    children:
+      divinity.runes.cmd: true
+      divinity.runes.gui: true
+
+  divinity.runes.cmd:
+    description: Access to all Runes commands.
+    default: op
+    children:
+      divinity.runes.cmd.merchant: true
+      divinity.runes.cmd.merchant.others: true
+  divinity.runes.cmd.merchant:
+    description: Access to /runes merchant command.
+    default: op
+  divinity.runes.cmd.merchant.others:
+    description: Access to /runes merchant [player] command.
+    default: op
+
+  divinity.runes.gui:
+    description: Access to all Runes GUIs.
+    default: op
+    children:
+      divinity.runes.gui.user: true
+      divinity.runes.gui.merchant: true
+  divinity.runes.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+  divinity.runes.gui.merchant:
     description: Access to Merchant Socketing GUI.
     default: op
 
   # Sell ----------------------------------------------------
-  divinity.sell:
-    description: Full access to the Sell module.
-    default: op
-    children:
-      divinity.sell.cmd: true
-      divinity.sell.gui: true
-      quantumrpg.sell.cmd: true
-      quantumrpg.sell.gui: true
-  divinity.sell.cmd:
-    description: Access to Sell commands.
-    default: op
-    children:
-      divinity.sell.cmd.open: true
-      quantumrpg.sell.cmd.open: true
-  divinity.sell.cmd.open:
-    description: Access to /sell open command.
-    default: op
-    children:
-      quantumrpg.sell.cmd.open: true
-  divinity.sell.gui:
-    description: Access to Sell GUI.
-    default: op
-    children:
-      quantumrpg.sell.gui: true
   quantumrpg.sell:
     description: Full access to the Sell module.
     default: op
     children:
       quantumrpg.sell.cmd: true
       quantumrpg.sell.gui: true
+      divinity.sell.cmd: true
+      divinity.sell.gui: true
   quantumrpg.sell.cmd:
     description: Access to Sell commands.
     default: op
     children:
       quantumrpg.sell.cmd.open: true
+      divinity.sell.cmd.open: true
+  quantumrpg.sell.cmd.open:
+    description: Access to /sell open command.
+    default: op
+    children:
+      divinity.sell.cmd.open: true
   quantumrpg.sell.gui:
+    description: Access to Sell GUI.
+    default: op
+    children:
+      divinity.sell.gui: true
+  divinity.sell:
+    description: Full access to the Sell module.
+    default: op
+    children:
+      divinity.sell.cmd: true
+      divinity.sell.gui: true
+  divinity.sell.cmd:
+    description: Access to Sell commands.
+    default: op
+    children:
+      divinity.sell.cmd.open: true
+  divinity.sell.gui:
     description: Access to Sell GUI.
     default: op
 
   # Soulbound ----------------------------------------------------
-  divinity.soulbound:
-    description: Access to Soulbound module.
-    default: op
-    children:
-      divinity.soulbound.cmd: true
-      quantumrpg.soulbound.cmd: true
-  divinity.soulbound.cmd:
-    description: Access to Soulbound commands.
-    default: op
-    children:
-      divinity.soulbound.cmd.soul: true
-      divinity.soulbound.cmd.untradeable: true
-      quantumrpg.soulbound.cmd.soul: true
-      quantumrpg.soulbound.cmd.untradeable: true
-  divinity.soulbound.cmd.soul:
-    description: Access to /soulbound soul command.
-    default: op
-    children:
-      quantumrpg.soulbound.cmd.soul: true
-  divinity.soulbound.cmd.untradeable:
-    description: Access to /soulbound untradeable command.
-    default: op
-    children:
-      quantumrpg.soulbound.cmd.untradeable: true
   quantumrpg.soulbound:
     description: Access to Soulbound module.
     default: op
     children:
       quantumrpg.soulbound.cmd: true
+      divinity.soulbound.cmd: true
   quantumrpg.soulbound.cmd:
     description: Access to Soulbound commands.
     default: op
     children:
       quantumrpg.soulbound.cmd.soul: true
       quantumrpg.soulbound.cmd.untradeable: true
+      divinity.soulbound.cmd.soul: true
+      divinity.soulbound.cmd.untradeable: true
+  quantumrpg.soulbound.cmd.soul:
+    description: Access to /soulbound soul command.
+    default: op
+    children:
+      divinity.soulbound.cmd.soul: true
+  quantumrpg.soulbound.cmd.untradeable:
+    description: Access to /soulbound untradeable command.
+    default: op
+    children:
+      divinity.soulbound.cmd.untradeable: true
+  divinity.soulbound:
+    description: Access to Soulbound module.
+    default: op
+    children:
+      divinity.soulbound.cmd: true
+  divinity.soulbound.cmd:
+    description: Access to Soulbound commands.
+    default: op
+    children:
+      divinity.soulbound.cmd.soul: true
+      divinity.soulbound.cmd.untradeable: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,38 +58,28 @@ permissions:
     description: Bypass all item player requirements.
     default: op
     children:
-      quantumrpg.bypass.requirement: true
-      divinity.bypass.requirement.class: true
-      divinity.bypass.requirement.level: true
-      divinity.bypass.requirement.soulbound: true
-      divinity.bypass.requirement.untradeable: true
+      divinity.bypass.class: true
+      divinity.bypass.level: true
+      divinity.bypass.soulbound: true
+      divinity.bypass.untradeable: true
   divinity.bypass.requirement.level:
     description: Bypass item player level requirement.
     default: op
-    children:
-      quantumrpg.bypass.requirement.level: true
   divinity.bypass.requirement.class:
     description: Bypass item player class requirement.
     default: op
-    children:
-      quantumrpg.bypass.requirement.class: true
   divinity.bypass.requirement.soulbound:
     description: Bypass item player soulbound requirement.
     default: op
-    children:
-      quantumrpg.bypass.requirement.soulbound: true
   divinity.bypass.requirement.untradeable:
     description: Bypass item untradeable requirement.
     default: op
 
-    children:
-      quantumrpg.bypass.requirement.untradeable: true
   # Classes ----------------------------------------------------
   divinity.classes:
     description: Full access to Classes module.
     default: op
     children:
-      quantumrpg.classes: true
       divinity.classes.cmd: true
       divinity.classes.class.*: true
   divinity.classes.cmd:
@@ -103,13 +93,6 @@ permissions:
       divinity.classes.cmd.aspects: true
       divinity.classes.cmd.addexp: true
       divinity.classes.cmd.addlevel: true
-      divinity.classes.cmd.addskill: true
-      divinity.classes.cmd.addaspectpoints: true
-      divinity.classes.cmd.addskillpoints: true
-      divinity.classes.cmd.setclass: true
-      divinity.classes.cmd.reset: true
-      divinity.classes.cmd.resetaspectpoints: true
-      divinity.classes.cmd.resetskillpoints: true
       quantumrpg.classes.cmd.addskill: true
       quantumrpg.classes.cmd.addaspectpoints: true
       quantumrpg.classes.cmd.addskillpoints: true
@@ -117,79 +100,6 @@ permissions:
       quantumrpg.classes.cmd.reset: true
       quantumrpg.classes.cmd.resetaspectpoints: true
       quantumrpg.classes.cmd.resetskillpoints: true
-  divinity.classes.cmd.cast:
-    description: Access to /class cast command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.cast: true
-  divinity.classes.cmd.select:
-    description: Access to /class select command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.select: true
-  divinity.classes.cmd.skills:
-    description: Access to /class skills command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.skills: true
-  divinity.classes.cmd.stats:
-    description: Access to /class stats command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.stats: true
-  divinity.classes.cmd.aspects:
-    description: Access to /class aspects command.
-    default: true
-    children:
-      quantumrpg.classes.cmd.aspects: true
-  divinity.classes.cmd.addexp:
-    description: Access to /class addexp command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addexp: true
-  divinity.classes.cmd.addlevel:
-    description: Access to /class addlevel command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addlevel: true
-  divinity.classes.cmd.addskill:
-    description: Access to /class addskill command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addskill: true
-  divinity.classes.cmd.addaspectpoints:
-    description: Access to /class addaspectpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addaspectpoints: true
-  divinity.classes.cmd.addskillpoints:
-    description: Access to /class addskillpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.addskillpoints: true
-  divinity.classes.cmd.setclass:
-    description: Access to /class setclass command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.setclass: true
-  divinity.classes.cmd.reset:
-    description: Access to /class reset command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.reset: true
-  divinity.classes.cmd.resetaspectpoints:
-    description: Access to /class resetaspectpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.resetaspectpoints: true
-  divinity.classes.cmd.resetskillpoints:
-    description: Access to /class resetskillpoints command.
-    default: op
-    children:
-      quantumrpg.classes.cmd.resetskillpoints: true
-  divinity.classes.class.*:
-    description: Access to all classes.
-    default: op
   quantumrpg.classes.cmd.cast:
     description: Access to /class cast command.
     default: op
@@ -234,23 +144,6 @@ permissions:
     default: op
 
   # Combat Log ----------------------------------------------------
-  divinity.combatlog:
-    description: Full access to Combat Log module.
-    default: op
-    children:
-      divinity.combatlog.cmd: true
-      quantumrpg.combatlog.cmd: true
-  divinity.combatlog.cmd:
-    description: Access to all Combat Log commands.
-    default: op
-    children:
-      divinity.combatlog.cmd.log: true
-      quantumrpg.combatlog.cmd.log: true
-  divinity.combatlog.cmd.log:
-    description: Access to /combatlog log command.
-    default: true
-    children:
-      quantumrpg.combatlog.cmd.log: true
   quantumrpg.combatlog:
     description: Full access to Combat Log module.
     default: op
@@ -266,30 +159,6 @@ permissions:
     default: true
 
   # Dismantle ----------------------------------------------------
-  divinity.dismantle:
-    description: Full access to the Dismantle module.
-    default: op
-    children:
-      divinity.dismantle.cmd: true
-      divinity.dismantle.gui: true
-      quantumrpg.dismantle.cmd: true
-      quantumrpg.dismantle.gui: true
-  divinity.dismantle.cmd:
-    description: Access to Dismantle commands.
-    default: op
-    children:
-      divinity.dismantle.cmd.open: true
-      quantumrpg.dismantle.cmd.open: true
-  divinity.dismantle.cmd.open:
-    description: Access to /dismantle open command.
-    default: op
-    children:
-      quantumrpg.dismantle.cmd.open: true
-  divinity.dismantle.gui:
-    description: Access to Dismantle GUI.
-    default: op
-    children:
-      quantumrpg.dismantle.gui: true
   quantumrpg.dismantle:
     description: Full access to the Dismantle module.
     default: op
@@ -306,50 +175,6 @@ permissions:
     default: op
 
   # Essences ----------------------------------------------------
-  divinity.essences:
-    description: Full access to Essences module.
-    default: op
-    children:
-      divinity.essences.cmd: true
-      divinity.essences.gui: true
-      quantumrpg.essences.cmd: true
-      quantumrpg.essences.gui: true
-  divinity.essences.cmd:
-    description: Access to all Essences commands.
-    default: op
-    children:
-      divinity.essences.cmd.merchant: true
-      divinity.essences.cmd.merchant.others: true
-      quantumrpg.essences.cmd.merchant: true
-      quantumrpg.essences.cmd.merchant.others: true
-  divinity.essences.cmd.merchant:
-    description: Access to /essences merchant command.
-    default: op
-    children:
-      quantumrpg.essences.cmd.merchant: true
-  divinity.essences.cmd.merchant.others:
-    description: Access to /essences merchant [player] command.
-    default: op
-    children:
-      quantumrpg.essences.cmd.merchant.others: true
-  divinity.essences.gui:
-    description: Access to all Essences GUIs.
-    default: op
-    children:
-      divinity.essences.gui.user: true
-      divinity.essences.gui.merchant: true
-      quantumrpg.essences.gui.user: true
-      quantumrpg.essences.gui.merchant: true
-  divinity.essences.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      quantumrpg.essences.gui.user: true
-  divinity.essences.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      quantumrpg.essences.gui.merchant: true
   quantumrpg.essences:
     description: Full access to Essences module.
     default: op
@@ -384,30 +209,6 @@ permissions:
     default: op
 
   # Extractor ----------------------------------------------------
-  divinity.extractor:
-    description: Full access to Extractor module.
-    default: op
-    children:
-      divinity.extractor.cmd: true
-      divinity.extractor.gui: true
-      quantumrpg.extractor.cmd: true
-      quantumrpg.extractor.gui: true
-  divinity.extractor.cmd:
-    description: Access to all Extractor commands.
-    default: op
-    children:
-      divinity.extractor.cmd.open: true
-      quantumrpg.extractor.cmd.open: true
-  divinity.extractor.cmd.open:
-    description: Access to /extractor open command.
-    default: op
-    children:
-      quantumrpg.extractor.cmd.open: true
-  divinity.extractor.gui:
-    description: Access Extractor GUI.
-    default: op
-    children:
-      quantumrpg.extractor.gui: true
   quantumrpg.extractor:
     description: Full access to Extractor module.
     default: op
@@ -427,30 +228,6 @@ permissions:
     default: op
 
   # Fortify ----------------------------------------------------
-  divinity.fortify:
-    description: Full access to Fortify module.
-    default: op
-    children:
-      divinity.fortify.cmd: true
-      quantumrpg.fortify.cmd: true
-  divinity.fortify.cmd:
-    description: Access to all Fortify commands.
-    default: op
-    children:
-      divinity.fortify.cmd.fortify: true
-      divinity.fortify.cmd.unfortify: true
-      quantumrpg.fortify.cmd.fortify: true
-      quantumrpg.fortify.cmd.unfortify: true
-  divinity.fortify.cmd.fortify:
-    description: Access to /fortify fortify command.
-    default: op
-    children:
-      quantumrpg.fortify.cmd.fortify: true
-  divinity.fortify.cmd.unfortify:
-    description: Access to /fortify unfortify command.
-    default: op
-    children:
-      quantumrpg.fortify.cmd.unfortify: true
   quantumrpg.fortify:
     description: Full access to Fortify module.
     default: op
@@ -470,50 +247,6 @@ permissions:
     default: op
 
   # Gems ----------------------------------------------------
-  divinity.gems:
-    description: Full access to Gems module.
-    default: op
-    children:
-      divinity.gems.cmd: true
-      divinity.gems.gui: true
-      quantumrpg.gems.cmd: true
-      quantumrpg.gems.gui: true
-  divinity.gems.cmd:
-    description: Access to all Gems commands.
-    default: op
-    children:
-      divinity.gems.cmd.merchant: true
-      divinity.gems.cmd.merchant.others: true
-      quantumrpg.gems.cmd.merchant: true
-      quantumrpg.gems.cmd.merchant.others: true
-  divinity.gems.cmd.merchant:
-    description: Access to /gems merchant command.
-    default: op
-    children:
-      quantumrpg.gems.cmd.merchant: true
-  divinity.gems.cmd.merchant.others:
-    description: Access to /gems merchant [player] command.
-    default: op
-    children:
-      quantumrpg.gems.cmd.merchant.others: true
-  divinity.gems.gui:
-    description: Access to all Gems GUIs.
-    default: op
-    children:
-      divinity.gems.gui.user: true
-      divinity.gems.gui.merchant: true
-      quantumrpg.gems.gui.user: true
-      quantumrpg.gems.gui.merchant: true
-  divinity.gems.gui.user:
-    description: Access to user socketing GUI.
-    default: op
-    children:
-      quantumrpg.gems.gui.user: true
-  divinity.gems.gui.merchant:
-    description: Access to Merchant socketing GUI.
-    default: op
-    children:
-      quantumrpg.gems.gui.merchant: true
   quantumrpg.gems:
     description: Full access to Gems module.
     default: op
@@ -546,23 +279,6 @@ permissions:
     default: op
 
   # Identify ----------------------------------------------------
-  divinity.identify:
-    description: Full access to Identify module.
-    default: op
-    children:
-      divinity.identify.cmd: true
-      quantumrpg.identify.cmd: true
-  divinity.identify.cmd:
-    description: Access to all Identify commands.
-    default: op
-    children:
-      divinity.identify.cmd.identify: true
-      quantumrpg.identify.cmd.identify: true
-  divinity.identify.cmd.identify:
-    description: Access to /identify identify command.
-    default: op
-    children:
-      quantumrpg.identify.cmd.identify: true
   quantumrpg.identify:
     description: Full access to Identify module.
     default: op
@@ -578,30 +294,6 @@ permissions:
     default: op
 
   # Magic Dust ----------------------------------------------------
-  divinity.magicdust:
-    description: Full access to Magic Dust module.
-    default: op
-    children:
-      divinity.magicdust.cmd: true
-      divinity.magicdust.gui: true
-      quantumrpg.magicdust.cmd: true
-      quantumrpg.magicdust.gui: true
-  divinity.magicdust.cmd:
-    description: Full access to Magic Dust commands.
-    default: op
-    children:
-      divinity.magicdust.cmd.open: true
-      quantumrpg.magicdust.cmd.open: true
-  divinity.magicdust.cmd.open:
-    description: Allows to use /magicdust open command.
-    default: op
-    children:
-      quantumrpg.magicdust.cmd.open: true
-  divinity.magicdust.gui:
-    description: Allows to use Magic Dust GUI.
-    default: op
-    children:
-      quantumrpg.magicdust.gui: true
   quantumrpg.magicdust:
     description: Full access to Magic Dust module.
     default: op
@@ -621,100 +313,6 @@ permissions:
     default: op
 
   # Party ----------------------------------------------------
-  divinity.party:
-    description: Access to Party module.
-    default: true
-    children:
-      divinity.party.cmd: true
-      quantumrpg.party.cmd: true
-  divinity.party.cmd:
-    description: Access to Party commands.
-    default: op
-    children:
-      divinity.party.cmd.chat: true
-      divinity.party.cmd.create: true
-      divinity.party.cmd.disband: true
-      divinity.party.cmd.drop: true
-      divinity.party.cmd.exp: true
-      divinity.party.cmd.invite: true
-      divinity.party.cmd.join: true
-      divinity.party.cmd.kick: true
-      divinity.party.cmd.leave: true
-      divinity.party.cmd.menu: true
-      divinity.party.cmd.roll: true
-      divinity.party.cmd.tp: true
-      quantumrpg.party.cmd.chat: true
-      quantumrpg.party.cmd.create: true
-      quantumrpg.party.cmd.disband: true
-      quantumrpg.party.cmd.drop: true
-      quantumrpg.party.cmd.exp: true
-      quantumrpg.party.cmd.invite: true
-      quantumrpg.party.cmd.join: true
-      quantumrpg.party.cmd.kick: true
-      quantumrpg.party.cmd.leave: true
-      quantumrpg.party.cmd.menu: true
-      quantumrpg.party.cmd.roll: true
-      quantumrpg.party.cmd.tp: true
-  divinity.party.cmd.chat:
-    description: Access to /party chat command.
-    default: true
-    children:
-      quantumrpg.party.cmd.chat: true
-  divinity.party.cmd.create:
-    description: Access to /party create command.
-    default: true
-    children:
-      quantumrpg.party.cmd.create: true
-  divinity.party.cmd.disband:
-    description: Access to /party disband command.
-    default: true
-    children:
-      quantumrpg.party.cmd.disband: true
-  divinity.party.cmd.drop:
-    description: Access to /party drop command.
-    default: true
-    children:
-      quantumrpg.party.cmd.drop: true
-  divinity.party.cmd.exp:
-    description: Access to /party exp command.
-    default: true
-    children:
-      quantumrpg.party.cmd.exp: true
-  divinity.party.cmd.invite:
-    description: Access to /party invite command.
-    default: true
-    children:
-      quantumrpg.party.cmd.invite: true
-  divinity.party.cmd.join:
-    description: Access to /party join command.
-    default: true
-    children:
-      quantumrpg.party.cmd.join: true
-  divinity.party.cmd.kick:
-    description: Access to /party kick command.
-    default: true
-    children:
-      quantumrpg.party.cmd.kick: true
-  divinity.party.cmd.leave:
-    description: Access to /party leave command.
-    default: true
-    children:
-      quantumrpg.party.cmd.leave: true
-  divinity.party.cmd.menu:
-    description: Access to /party menu command.
-    default: true
-    children:
-      quantumrpg.party.cmd.menu: true
-  divinity.party.cmd.roll:
-    description: Access to /party roll command.
-    default: true
-    children:
-      quantumrpg.party.cmd.roll: true
-  divinity.party.cmd.tp:
-    description: Access to /party tp command.
-    default: true
-    children:
-      quantumrpg.party.cmd.tp: true
   quantumrpg.party:
     description: Access to Party module.
     default: true
@@ -774,30 +372,6 @@ permissions:
     default: true
 
   # Refine ----------------------------------------------------
-  divinity.refine:
-    description: Access to Refine module.
-    default: op
-    children:
-      divinity.refine.cmd: true
-      quantumrpg.refine.cmd: true
-  divinity.refine.cmd:
-    description: Access to Refine commands.
-    default: op
-    children:
-      divinity.refine.cmd.refine: true
-      divinity.refine.cmd.downgrade: true
-      quantumrpg.refine.cmd.refine: true
-      quantumrpg.refine.cmd.downgrade: true
-  divinity.refine.cmd.refine:
-    description: Access to /refine refine command.
-    default: op
-    children:
-      quantumrpg.refine.cmd.refine: true
-  divinity.refine.cmd.downgrade:
-    description: Access to /refine downgrade command.
-    default: op
-    children:
-      quantumrpg.refine.cmd.downgrade: true
   quantumrpg.refine:
     description: Access to Refine module.
     default: op
@@ -811,30 +385,6 @@ permissions:
       quantumrpg.refine.cmd.downgrade: true
 
   # Repair ----------------------------------------------------
-  divinity.repair:
-    description: Access to Repair module.
-    default: op
-    children:
-      divinity.repair.cmd: true
-      divinity.repair.gui: true
-      quantumrpg.repair.cmd: true
-      quantumrpg.repair.gui: true
-  divinity.repair.cmd:
-    description: Access to Repair commands.
-    default: op
-    children:
-      divinity.repair.cmd.open: true
-      quantumrpg.repair.cmd.open: true
-  divinity.repair.cmd.open:
-    description: Access to /repair open command.
-    default: op
-    children:
-      quantumrpg.repair.cmd.open: true
-  divinity.repair.gui:
-    description: Access to Repair GUI.
-    default: op
-    children:
-      quantumrpg.repair.gui: true
   quantumrpg.repair:
     description: Access to Repair module.
     default: op
@@ -851,50 +401,6 @@ permissions:
     default: op
 
   # Runes ----------------------------------------------------
-  divinity.runes:
-    description: Full access to Runes module.
-    default: op
-    children:
-      divinity.runes.cmd: true
-      divinity.runes.gui: true
-      quantumrpg.runes.cmd: true
-      quantumrpg.runes.gui: true
-  divinity.runes.cmd:
-    description: Access to all Runes commands.
-    default: op
-    children:
-      divinity.runes.cmd.merchant: true
-      divinity.runes.cmd.merchant.others: true
-      quantumrpg.runes.cmd.merchant: true
-      quantumrpg.runes.cmd.merchant.others: true
-  divinity.runes.cmd.merchant:
-    description: Access to /runes merchant command.
-    default: op
-    children:
-      quantumrpg.runes.cmd.merchant: true
-  divinity.runes.cmd.merchant.others:
-    description: Access to /runes merchant [player] command.
-    default: op
-    children:
-      quantumrpg.runes.cmd.merchant.others: true
-  divinity.runes.gui:
-    description: Access to all Runes GUIs.
-    default: op
-    children:
-      divinity.runes.gui.user: true
-      divinity.runes.gui.merchant: true
-      quantumrpg.runes.gui.user: true
-      quantumrpg.runes.gui.merchant: true
-  divinity.runes.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      quantumrpg.runes.gui.user: true
-  divinity.runes.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      quantumrpg.runes.gui.merchant: true
   quantumrpg.runes:
     description: Full access to Runes module.
     default: op
@@ -929,30 +435,6 @@ permissions:
     default: op
 
   # Sell ----------------------------------------------------
-  divinity.sell:
-    description: Full access to the Sell module.
-    default: op
-    children:
-      divinity.sell.cmd: true
-      divinity.sell.gui: true
-      quantumrpg.sell.cmd: true
-      quantumrpg.sell.gui: true
-  divinity.sell.cmd:
-    description: Access to Sell commands.
-    default: op
-    children:
-      divinity.sell.cmd.open: true
-      quantumrpg.sell.cmd.open: true
-  divinity.sell.cmd.open:
-    description: Access to /sell open command.
-    default: op
-    children:
-      quantumrpg.sell.cmd.open: true
-  divinity.sell.gui:
-    description: Access to Sell GUI.
-    default: op
-    children:
-      quantumrpg.sell.gui: true
   quantumrpg.sell:
     description: Full access to the Sell module.
     default: op
@@ -969,30 +451,6 @@ permissions:
     default: op
 
   # Soulbound ----------------------------------------------------
-  divinity.soulbound:
-    description: Access to Soulbound module.
-    default: op
-    children:
-      divinity.soulbound.cmd: true
-      quantumrpg.soulbound.cmd: true
-  divinity.soulbound.cmd:
-    description: Access to Soulbound commands.
-    default: op
-    children:
-      divinity.soulbound.cmd.soul: true
-      divinity.soulbound.cmd.untradeable: true
-      quantumrpg.soulbound.cmd.soul: true
-      quantumrpg.soulbound.cmd.untradeable: true
-  divinity.soulbound.cmd.soul:
-    description: Access to /soulbound soul command.
-    default: op
-    children:
-      quantumrpg.soulbound.cmd.soul: true
-  divinity.soulbound.cmd.untradeable:
-    description: Access to /soulbound untradeable command.
-    default: op
-    children:
-      quantumrpg.soulbound.cmd.untradeable: true
   quantumrpg.soulbound:
     description: Access to Soulbound module.
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -44,85 +44,99 @@ permissions:
       divinity.repair: true
       divinity.sell: true
       divinity.soulbound: true
-
-  divinity.user:
-    description: User access
-    default: true
-
-  # Legacy aliases kept so servers granting the old quantumrpg.* nodes
-  # directly (instead of divinity.*) don't need to change anything.
   quantumrpg.admin:
     description: Legacy alias for divinity.admin.
     default: op
     children:
       divinity.admin: true
+
+  divinity.user:
+    description: User access
+    default: true
   quantumrpg.user:
     description: Legacy alias for divinity.user.
     default: true
     children:
       divinity.user: true
 
-  quantumrpg.bypass:
+  divinity.bypass:
     description: Bypass all the plugin restrictions and requirements.
     default: op
     children:
-      quantumrpg.bypass.requirement: true
-  quantumrpg.bypass.requirement:
+      divinity.bypass.requirement: true
+  quantumrpg.bypass:
+    description: Legacy alias for divinity.bypass.
+    default: op
+    children:
+      divinity.bypass: true
+  divinity.bypass.requirement:
     description: Bypass all item player requirements.
     default: op
     children:
+      divinity.bypass.requirement.class: true
+      divinity.bypass.requirement.level: true
+      divinity.bypass.requirement.soulbound: true
+      divinity.bypass.requirement.untradeable: true
+  quantumrpg.bypass.requirement:
+    description: Legacy alias for divinity.bypass.requirement.
+    default: op
+    children:
       divinity.bypass.requirement: true
-      quantumrpg.bypass.requirement.class: true
-      quantumrpg.bypass.requirement.level: true
-      quantumrpg.bypass.requirement.soulbound: true
-      quantumrpg.bypass.requirement.untradeable: true
-  quantumrpg.bypass.requirement.level:
+  divinity.bypass.requirement.level:
     description: Bypass item player level requirement.
+    default: op
+  quantumrpg.bypass.requirement.level:
+    description: Legacy alias for divinity.bypass.requirement.level.
     default: op
     children:
       divinity.bypass.requirement.level: true
-  quantumrpg.bypass.requirement.class:
+  divinity.bypass.requirement.class:
     description: Bypass item player class requirement.
+    default: op
+  quantumrpg.bypass.requirement.class:
+    description: Legacy alias for divinity.bypass.requirement.class.
     default: op
     children:
       divinity.bypass.requirement.class: true
-  quantumrpg.bypass.requirement.soulbound:
+  divinity.bypass.requirement.soulbound:
     description: Bypass item player soulbound requirement.
+    default: op
+  quantumrpg.bypass.requirement.soulbound:
+    description: Legacy alias for divinity.bypass.requirement.soulbound.
     default: op
     children:
       divinity.bypass.requirement.soulbound: true
-  quantumrpg.bypass.requirement.untradeable:
+  divinity.bypass.requirement.untradeable:
     description: Bypass item untradeable requirement.
     default: op
-
+  quantumrpg.bypass.requirement.untradeable:
+    description: Legacy alias for divinity.bypass.requirement.untradeable.
+    default: op
     children:
       divinity.bypass.requirement.untradeable: true
   # Classes ----------------------------------------------------
-  quantumrpg.classes:
+  divinity.classes:
     description: Full access to Classes module.
     default: op
     children:
+      divinity.classes.cmd: true
+      divinity.classes.class.*: true
+  quantumrpg.classes:
+    description: Legacy alias for divinity.classes.
+    default: op
+    children:
       divinity.classes: true
-      quantumrpg.classes.cmd: true
-      quantumrpg.classes.class.*: true
-  quantumrpg.classes.cmd:
+  divinity.classes.cmd:
     description: Full access to Classes commands.
     default: op
     children:
-      quantumrpg.classes.cmd.cast: true
-      quantumrpg.classes.cmd.select: true
-      quantumrpg.classes.cmd.skills: true
-      quantumrpg.classes.cmd.stats: true
-      quantumrpg.classes.cmd.aspects: true
-      quantumrpg.classes.cmd.addexp: true
-      quantumrpg.classes.cmd.addlevel: true
-      quantumrpg.classes.cmd.addskill: true
-      quantumrpg.classes.cmd.addaspectpoints: true
-      quantumrpg.classes.cmd.addskillpoints: true
-      quantumrpg.classes.cmd.setclass: true
-      quantumrpg.classes.cmd.reset: true
-      quantumrpg.classes.cmd.resetaspectpoints: true
-      quantumrpg.classes.cmd.resetskillpoints: true
+      divinity.classes.cmd.cast: true
+      divinity.classes.cmd.select: true
+      divinity.classes.cmd.skills: true
+      divinity.classes.cmd.stats: true
+      divinity.classes.cmd.aspects: true
+      divinity.classes.cmd.addexp: true
+      divinity.classes.cmd.addlevel: true
       divinity.classes.cmd.addskill: true
       divinity.classes.cmd.addaspectpoints: true
       divinity.classes.cmd.addskillpoints: true
@@ -130,609 +144,524 @@ permissions:
       divinity.classes.cmd.reset: true
       divinity.classes.cmd.resetaspectpoints: true
       divinity.classes.cmd.resetskillpoints: true
+  quantumrpg.classes.cmd:
+    description: Legacy alias for divinity.classes.cmd.
+    default: op
+    children:
+      divinity.classes.cmd: true
+  divinity.classes.cmd.cast:
+    description: Access to /class cast command.
+    default: op
   quantumrpg.classes.cmd.cast:
     description: Access to /class cast command.
     default: op
     children:
       divinity.classes.cmd.cast: true
+  divinity.classes.cmd.select:
+    description: Access to /class select command.
+    default: true
   quantumrpg.classes.cmd.select:
     description: Access to /class select command.
     default: true
     children:
       divinity.classes.cmd.select: true
+  divinity.classes.cmd.skills:
+    description: Access to /class skills command.
+    default: true
   quantumrpg.classes.cmd.skills:
     description: Access to /class skills command.
     default: true
     children:
       divinity.classes.cmd.skills: true
+  divinity.classes.cmd.stats:
+    description: Access to /class stats command.
+    default: true
   quantumrpg.classes.cmd.stats:
     description: Access to /class stats command.
     default: true
     children:
       divinity.classes.cmd.stats: true
+  divinity.classes.cmd.aspects:
+    description: Access to /class aspects command.
+    default: true
   quantumrpg.classes.cmd.aspects:
     description: Access to /class aspects command.
     default: true
     children:
       divinity.classes.cmd.aspects: true
+  divinity.classes.cmd.addexp:
+    description: Access to /class addexp command.
+    default: op
   quantumrpg.classes.cmd.addexp:
     description: Access to /class addexp command.
     default: op
     children:
       divinity.classes.cmd.addexp: true
+  divinity.classes.cmd.addlevel:
+    description: Access to /class addlevel command.
+    default: op
   quantumrpg.classes.cmd.addlevel:
     description: Access to /class addlevel command.
     default: op
     children:
       divinity.classes.cmd.addlevel: true
-  quantumrpg.classes.cmd.addskill:
+  divinity.classes.cmd.addskill:
     description: Access to /class addskill command.
+    default: op
+  quantumrpg.classes.cmd.addskill:
+    description: Legacy alias for divinity.classes.cmd.addskill.
     default: op
     children:
       divinity.classes.cmd.addskill: true
+  divinity.classes.cmd.addaspectpoints:
+    description: Access to /class addaspectpoints command.
+    default: op
   quantumrpg.classes.cmd.addaspectpoints:
     description: Access to /class addaspectpoints command.
     default: op
     children:
       divinity.classes.cmd.addaspectpoints: true
+  divinity.classes.cmd.addskillpoints:
+    description: Access to /class addskillpoints command.
+    default: op
   quantumrpg.classes.cmd.addskillpoints:
     description: Access to /class addskillpoints command.
     default: op
     children:
       divinity.classes.cmd.addskillpoints: true
+  divinity.classes.cmd.setclass:
+    description: Access to /class setclass command.
+    default: op
   quantumrpg.classes.cmd.setclass:
     description: Access to /class setclass command.
     default: op
     children:
       divinity.classes.cmd.setclass: true
+  divinity.classes.cmd.reset:
+    description: Access to /class reset command.
+    default: op
   quantumrpg.classes.cmd.reset:
     description: Access to /class reset command.
     default: op
     children:
       divinity.classes.cmd.reset: true
+  divinity.classes.cmd.resetaspectpoints:
+    description: Access to /class resetaspectpoints command.
+    default: op
   quantumrpg.classes.cmd.resetaspectpoints:
     description: Access to /class resetaspectpoints command.
     default: op
     children:
       divinity.classes.cmd.resetaspectpoints: true
+  divinity.classes.cmd.resetskillpoints:
+    description: Access to /class resetskillpoints command.
+    default: op
   quantumrpg.classes.cmd.resetskillpoints:
     description: Access to /class resetskillpoints command.
     default: op
     children:
       divinity.classes.cmd.resetskillpoints: true
-  quantumrpg.classes.class.*:
-    description: Access to all classes.
-    default: op
-  divinity.classes.cmd.cast:
-    description: Access to /class cast command.
-    default: op
-  divinity.classes.cmd.select:
-    description: Access to /class select command.
-    default: true
-  divinity.classes.cmd.skills:
-    description: Access to /class skills command.
-    default: true
-  divinity.classes.cmd.stats:
-    description: Access to /class stats command.
-    default: true
-  divinity.classes.cmd.aspects:
-    description: Access to /class aspects command.
-    default: true
-  divinity.classes.cmd.addexp:
-    description: Access to /class addexp command.
-    default: op
-  divinity.classes.cmd.addskillpoints:
-    description: Access to /class addskillpoints command.
-    default: op
-  divinity.classes.cmd.addaspectpoints:
-    description: Access to /class addaspectpoints command.
-    default: op
-  divinity.classes.cmd.addlevel:
-    description: Access to /class addlevel command.
-    default: op
-  divinity.classes.cmd.setclass:
-    description: Access to /class setclass command.
-    default: op
-  divinity.classes.cmd.reset:
-    description: Access to /class reset command.
-    default: op
-  divinity.classes.cmd.resetaspectpoints:
-    description: Access to /class resetaspectpoints command.
-    default: op
-  divinity.classes.cmd.resetskillpoints:
-    description: Access to /class resetskillpoints command.
-    default: op
   divinity.classes.class.*:
     description: Access to all classes.
     default: op
+  quantumrpg.classes.class.*:
+    description: Access to all classes.
+    default: op
+    children:
+      divinity.classes.class.*: true
 
   # Combat Log ----------------------------------------------------
-  quantumrpg.combatlog:
-    description: Full access to Combat Log module.
-    default: op
-    children:
-      quantumrpg.combatlog.cmd: true
-      divinity.combatlog.cmd: true
-  quantumrpg.combatlog.cmd:
-    description: Access to all Combat Log commands.
-    default: op
-    children:
-      quantumrpg.combatlog.cmd.log: true
-      divinity.combatlog.cmd.log: true
-  quantumrpg.combatlog.cmd.log:
-    description: Access to /combatlog log command.
-    default: true
-    children:
-      divinity.combatlog.cmd.log: true
   divinity.combatlog:
     description: Full access to Combat Log module.
     default: op
     children:
       divinity.combatlog.cmd: true
+  quantumrpg.combatlog:
+    description: Full access to Combat Log module.
+    default: op
+    children:
+      quantumrpg.combatlog.cmd: true
+      divinity.combatlog: true
   divinity.combatlog.cmd:
     description: Access to all Combat Log commands.
     default: op
     children:
       divinity.combatlog.cmd.log: true
+  quantumrpg.combatlog.cmd:
+    description: Access to all Combat Log commands.
+    default: op
+    children:
+      quantumrpg.combatlog.cmd.log: true
+      divinity.combatlog.cmd: true
   divinity.combatlog.cmd.log:
     description: Access to /combatlog log command.
     default: true
+  quantumrpg.combatlog.cmd.log:
+    description: Access to /combatlog log command.
+    default: true
+    children:
+      divinity.combatlog.cmd.log: true
 
   # Dismantle ----------------------------------------------------
-  quantumrpg.dismantle:
-    description: Full access to the Dismantle module.
-    default: op
-    children:
-      quantumrpg.dismantle.cmd: true
-      quantumrpg.dismantle.gui: true
-      divinity.dismantle.cmd: true
-      divinity.dismantle.gui: true
-  quantumrpg.dismantle.cmd:
-    description: Access to Dismantle commands.
-    default: op
-    children:
-      quantumrpg.dismantle.cmd.open: true
-      divinity.dismantle.cmd.open: true
-  quantumrpg.dismantle.cmd.open:
-    description: Access to /dismantle open command.
-    default: op
-    children:
-      divinity.dismantle.cmd.open: true
-  quantumrpg.dismantle.gui:
-    description: Access to Dismantle GUI.
-    default: op
-    children:
-      divinity.dismantle.gui: true
   divinity.dismantle:
     description: Full access to the Dismantle module.
     default: op
     children:
       divinity.dismantle.cmd: true
       divinity.dismantle.gui: true
+  quantumrpg.dismantle:
+    description: Full access to the Dismantle module.
+    default: op
+    children:
+      quantumrpg.dismantle.cmd: true
+      quantumrpg.dismantle.gui: true
+      divinity.dismantle: true
   divinity.dismantle.cmd:
     description: Access to Dismantle commands.
+    default: op
+    children:
+      divinity.dismantle.cmd.open: true
+  quantumrpg.dismantle.cmd:
+    description: Access to Dismantle commands.
+    default: op
+    children:
+      quantumrpg.dismantle.cmd.open: true
+      divinity.dismantle.cmd: true
+  divinity.dismantle.cmd.open:
+    description: Access to /dismantle open command.
+    default: op
+  quantumrpg.dismantle.cmd.open:
+    description: Legacy alias for divinity.dismantle.cmd.open.
     default: op
     children:
       divinity.dismantle.cmd.open: true
   divinity.dismantle.gui:
     description: Access to Dismantle GUI.
     default: op
+  quantumrpg.dismantle.gui:
+    description: Access to Dismantle GUI.
+    default: op
+    children:
+      divinity.dismantle.gui: true
 
   # Essences ----------------------------------------------------
-  quantumrpg.essences:
-    description: Full access to Essences module.
-    default: op
-    children:
-      quantumrpg.essences.cmd: true
-      quantumrpg.essences.gui: true
-      divinity.essences.cmd: true
-      divinity.essences.gui: true
-  quantumrpg.essences.cmd:
-    description: Access to all Essences commands.
-    default: op
-    children:
-      quantumrpg.essences.cmd.merchant: true
-      quantumrpg.essences.cmd.merchant.others: true
-      divinity.essences.cmd.merchant: true
-      divinity.essences.cmd.merchant.others: true
-  quantumrpg.essences.cmd.merchant:
-    description: Access to /essences merchant command.
-    default: op
-    children:
-      divinity.essences.cmd.merchant: true
-  quantumrpg.essences.cmd.merchant.others:
-    description: Access to /essences merchant [player] command.
-    default: op
-    children:
-      divinity.essences.cmd.merchant.others: true
-  quantumrpg.essences.gui:
-    description: Access to all Essences GUIs.
-    default: op
-    children:
-      quantumrpg.essences.gui.user: true
-      quantumrpg.essences.gui.merchant: true
-      divinity.essences.gui.user: true
-      divinity.essences.gui.merchant: true
-  quantumrpg.essences.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      divinity.essences.gui.user: true
-  quantumrpg.essences.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      divinity.essences.gui.merchant: true
   divinity.essences:
     description: Full access to Essences module.
     default: op
     children:
       divinity.essences.cmd: true
       divinity.essences.gui: true
-
+  quantumrpg.essences:
+    description: Full access to Essences module.
+    default: op
+    children:
+      quantumrpg.essences.cmd: true
+      quantumrpg.essences.gui: true
+      divinity.essences: true
   divinity.essences.cmd:
     description: Access to all Essences commands.
     default: op
     children:
       divinity.essences.cmd.merchant: true
       divinity.essences.cmd.merchant.others: true
+  quantumrpg.essences.cmd:
+    description: Access to all Essences commands.
+    default: op
+    children:
+      quantumrpg.essences.cmd.merchant: true
+      quantumrpg.essences.cmd.merchant.others: true
+      divinity.essences.cmd: true
   divinity.essences.cmd.merchant:
     description: Access to /essences merchant command.
     default: op
+  quantumrpg.essences.cmd.merchant:
+    description: Access to /essences merchant command.
+    default: op
+    children:
+      divinity.essences.cmd.merchant: true
   divinity.essences.cmd.merchant.others:
     description: Access to /essences merchant [player] command.
     default: op
-
+  quantumrpg.essences.cmd.merchant.others:
+    description: Access to /essences merchant [player] command.
+    default: op
+    children:
+      divinity.essences.cmd.merchant.others: true
   divinity.essences.gui:
     description: Access to all Essences GUIs.
     default: op
     children:
       divinity.essences.gui.user: true
       divinity.essences.gui.merchant: true
+  quantumrpg.essences.gui:
+    description: Access to all Essences GUIs.
+    default: op
+    children:
+      quantumrpg.essences.gui.user: true
+      quantumrpg.essences.gui.merchant: true
+      divinity.essences.gui: true
   divinity.essences.gui.user:
     description: Access to Default Socketing GUI.
     default: op
+  quantumrpg.essences.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+    children:
+      divinity.essences.gui.user: true
   divinity.essences.gui.merchant:
     description: Access to Merchant Socketing GUI.
     default: op
+  quantumrpg.essences.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      divinity.essences.gui.merchant: true
+
+
 
   # Extractor ----------------------------------------------------
-  quantumrpg.extractor:
-    description: Full access to Extractor module.
-    default: op
-    children:
-      quantumrpg.extractor.cmd: true
-      quantumrpg.extractor.gui: true
-      divinity.extractor.cmd: true
-      divinity.extractor.gui: true
-  quantumrpg.extractor.cmd:
-    description: Access to all Extractor commands.
-    default: op
-    children:
-      quantumrpg.extractor.cmd.open: true
-      divinity.extractor.cmd.open: true
-  quantumrpg.extractor.cmd.open:
-    description: Access to /extractor open command.
-    default: op
-    children:
-      divinity.extractor.cmd.open: true
-  quantumrpg.extractor.gui:
-    description: Access Extractor GUI.
-    default: op
-    children:
-      divinity.extractor.gui: true
   divinity.extractor:
     description: Full access to Extractor module.
     default: op
     children:
       divinity.extractor.cmd: true
       divinity.extractor.gui: true
+  quantumrpg.extractor:
+    description: Full access to Extractor module.
+    default: op
+    children:
+      quantumrpg.extractor.cmd: true
+      quantumrpg.extractor.gui: true
+      divinity.extractor: true
   divinity.extractor.cmd:
     description: Access to all Extractor commands.
     default: op
     children:
       divinity.extractor.cmd.open: true
+  quantumrpg.extractor.cmd:
+    description: Access to all Extractor commands.
+    default: op
+    children:
+      quantumrpg.extractor.cmd.open: true
+      divinity.extractor.cmd: true
   divinity.extractor.cmd.open:
     description: Access to /extractor open command.
     default: op
+  quantumrpg.extractor.cmd.open:
+    description: Access to /extractor open command.
+    default: op
+    children:
+      divinity.extractor.cmd.open: true
   divinity.extractor.gui:
     description: Access Extractor GUI.
     default: op
+  quantumrpg.extractor.gui:
+    description: Access Extractor GUI.
+    default: op
+    children:
+      divinity.extractor.gui: true
 
   # Fortify ----------------------------------------------------
-  quantumrpg.fortify:
-    description: Full access to Fortify module.
-    default: op
-    children:
-      quantumrpg.fortify.cmd: true
-      divinity.fortify.cmd: true
-  quantumrpg.fortify.cmd:
-    description: Access to all Fortify commands.
-    default: op
-    children:
-      quantumrpg.fortify.cmd.fortify: true
-      quantumrpg.fortify.cmd.unfortify: true
-      divinity.fortify.cmd.fortify: true
-      divinity.fortify.cmd.unfortify: true
-  quantumrpg.fortify.cmd.fortify:
-    description: Access to /fortify fortify command.
-    default: op
-    children:
-      divinity.fortify.cmd.fortify: true
-  quantumrpg.fortify.cmd.unfortify:
-    description: Access to /fortify unfortify command.
-    default: op
-    children:
-      divinity.fortify.cmd.unfortify: true
   divinity.fortify:
     description: Full access to Fortify module.
     default: op
     children:
       divinity.fortify.cmd: true
+  quantumrpg.fortify:
+    description: Full access to Fortify module.
+    default: op
+    children:
+      quantumrpg.fortify.cmd: true
+      divinity.fortify: true
   divinity.fortify.cmd:
     description: Access to all Fortify commands.
     default: op
     children:
       divinity.fortify.cmd.fortify: true
       divinity.fortify.cmd.unfortify: true
+  quantumrpg.fortify.cmd:
+    description: Access to all Fortify commands.
+    default: op
+    children:
+      quantumrpg.fortify.cmd.fortify: true
+      quantumrpg.fortify.cmd.unfortify: true
+      divinity.fortify.cmd: true
   divinity.fortify.cmd.fortify:
     description: Access to /fortify fortify command.
     default: op
+  quantumrpg.fortify.cmd.fortify:
+    description: Access to /fortify fortify command.
+    default: op
+    children:
+      divinity.fortify.cmd.fortify: true
   divinity.fortify.cmd.unfortify:
     description: Access to /fortify unfortify command.
     default: op
+  quantumrpg.fortify.cmd.unfortify:
+    description: Access to /fortify unfortify command.
+    default: op
+    children:
+      divinity.fortify.cmd.unfortify: true
 
   # Gems ----------------------------------------------------
-  quantumrpg.gems:
-    description: Full access to Gems module.
-    default: op
-    children:
-      quantumrpg.gems.cmd: true
-      quantumrpg.gems.gui: true
-      divinity.gems.cmd: true
-      divinity.gems.gui: true
-  quantumrpg.gems.cmd:
-    description: Access to all Gems commands.
-    default: op
-    children:
-      quantumrpg.gems.cmd.merchant: true
-      quantumrpg.gems.cmd.merchant.others: true
-      divinity.gems.cmd.merchant: true
-      divinity.gems.cmd.merchant.others: true
-  quantumrpg.gems.cmd.merchant:
-    description: Access to /gems merchant command.
-    default: op
-    children:
-      divinity.gems.cmd.merchant: true
-  quantumrpg.gems.cmd.merchant.others:
-    description: Access to /gems merchant [player] command.
-    default: op
-    children:
-      divinity.gems.cmd.merchant.others: true
-  quantumrpg.gems.gui:
-    description: Access to all Gems GUIs.
-    default: op
-    children:
-      quantumrpg.gems.gui.user: true
-      quantumrpg.gems.gui.merchant: true
-      divinity.gems.gui.user: true
-      divinity.gems.gui.merchant: true
-  quantumrpg.gems.gui.user:
-    description: Access to user socketing GUI.
-    default: op
-    children:
-      divinity.gems.gui.user: true
-  quantumrpg.gems.gui.merchant:
-    description: Access to Merchant socketing GUI.
-    default: op
-    children:
-      divinity.gems.gui.merchant: true
   divinity.gems:
     description: Full access to Gems module.
     default: op
     children:
       divinity.gems.cmd: true
       divinity.gems.gui: true
+  quantumrpg.gems:
+    description: Full access to Gems module.
+    default: op
+    children:
+      quantumrpg.gems.cmd: true
+      quantumrpg.gems.gui: true
+      divinity.gems: true
   divinity.gems.cmd:
     description: Access to all Gems commands.
     default: op
     children:
       divinity.gems.cmd.merchant: true
       divinity.gems.cmd.merchant.others: true
+  quantumrpg.gems.cmd:
+    description: Access to all Gems commands.
+    default: op
+    children:
+      quantumrpg.gems.cmd.merchant: true
+      quantumrpg.gems.cmd.merchant.others: true
+      divinity.gems.cmd: true
   divinity.gems.cmd.merchant:
     description: Access to /gems merchant command.
     default: op
+  quantumrpg.gems.cmd.merchant:
+    description: Access to /gems merchant command.
+    default: op
+    children:
+      divinity.gems.cmd.merchant: true
   divinity.gems.cmd.merchant.others:
     description: Access to /gems merchant [player] command.
     default: op
+  quantumrpg.gems.cmd.merchant.others:
+    description: Access to /gems merchant [player] command.
+    default: op
+    children:
+      divinity.gems.cmd.merchant.others: true
   divinity.gems.gui:
     description: Access to all Gems GUIs.
     default: op
     children:
       divinity.gems.gui.user: true
       divinity.gems.gui.merchant: true
+  quantumrpg.gems.gui:
+    description: Access to all Gems GUIs.
+    default: op
+    children:
+      quantumrpg.gems.gui.user: true
+      quantumrpg.gems.gui.merchant: true
+      divinity.gems.gui: true
   divinity.gems.gui.user:
+    description: Access to user socketing GUI.
+    default: op
+  quantumrpg.gems.gui.user:
     description: Access to user GUI.
     default: op
+    children:
+      divinity.gems.gui.user: true
   divinity.gems.gui.merchant:
+    description: Access to Merchant socketing GUI.
+    default: op
+  quantumrpg.gems.gui.merchant:
     description: Access to Merchant GUI.
     default: op
+    children:
+      divinity.gems.gui.merchant: true
 
   # Identify ----------------------------------------------------
-  quantumrpg.identify:
-    description: Full access to Identify module.
-    default: op
-    children:
-      quantumrpg.identify.cmd: true
-      divinity.identify.cmd: true
-  quantumrpg.identify.cmd:
-    description: Access to all Identify commands.
-    default: op
-    children:
-      quantumrpg.identify.cmd.identify: true
-      divinity.identify.cmd.identify: true
-  quantumrpg.identify.cmd.identify:
-    description: Access to /identify identify command.
-    default: op
-    children:
-      divinity.identify.cmd.identify: true
   divinity.identify:
     description: Full access to Identify module.
     default: op
     children:
       divinity.identify.cmd: true
+  quantumrpg.identify:
+    description: Full access to Identify module.
+    default: op
+    children:
+      quantumrpg.identify.cmd: true
+      divinity.identify: true
   divinity.identify.cmd:
     description: Access to all Identify commands.
     default: op
     children:
       divinity.identify.cmd.identify: true
+  quantumrpg.identify.cmd:
+    description: Access to all Identify commands.
+    default: op
+    children:
+      quantumrpg.identify.cmd.identify: true
+      divinity.identify.cmd: true
   divinity.identify.cmd.identify:
     description: Access to /identify identify command.
     default: op
+  quantumrpg.identify.cmd.identify:
+    description: Access to /identify identify command.
+    default: op
+    children:
+      divinity.identify.cmd.identify: true
 
   # Magic Dust ----------------------------------------------------
-  quantumrpg.magicdust:
-    description: Full access to Magic Dust module.
-    default: op
-    children:
-      quantumrpg.magicdust.cmd: true
-      quantumrpg.magicdust.gui: true
-      divinity.magicdust.cmd: true
-      divinity.magicdust.gui: true
-  quantumrpg.magicdust.cmd:
-    description: Full access to Magic Dust commands.
-    default: op
-    children:
-      quantumrpg.magicdust.cmd.open: true
-      divinity.magicdust.cmd.open: true
-  quantumrpg.magicdust.cmd.open:
-    description: Allows to use /magicdust open command.
-    default: op
-    children:
-      divinity.magicdust.cmd.open: true
-  quantumrpg.magicdust.gui:
-    description: Allows to use Magic Dust GUI.
-    default: op
-    children:
-      divinity.magicdust.gui: true
   divinity.magicdust:
     description: Full access to Magic Dust module.
     default: op
     children:
       divinity.magicdust.cmd: true
       divinity.magicdust.gui: true
+  quantumrpg.magicdust:
+    description: Full access to Magic Dust module.
+    default: op
+    children:
+      quantumrpg.magicdust.cmd: true
+      quantumrpg.magicdust.gui: true
+      divinity.magicdust: true
   divinity.magicdust.cmd:
     description: Full access to Magic Dust commands.
     default: op
     children:
       divinity.magicdust.cmd.open: true
+  quantumrpg.magicdust.cmd:
+    description: Full access to Magic Dust commands.
+    default: op
+    children:
+      quantumrpg.magicdust.cmd.open: true
+      divinity.magicdust.cmd: true
   divinity.magicdust.cmd.open:
     description: Allows to use /magicdust open command.
     default: op
+  quantumrpg.magicdust.cmd.open:
+    description: Allows to use /magicdust open command.
+    default: op
+    children:
+      divinity.magicdust.cmd.open: true
   divinity.magicdust.gui:
     description: Allows to use Magic Dust GUI.
     default: op
-
-  # Party ----------------------------------------------------
-  quantumrpg.party:
-    description: Access to Party module.
-    default: true
-    children:
-      quantumrpg.party.cmd: true
-      divinity.party.cmd: true
-  quantumrpg.party.cmd:
-    description: Access to Party commands.
+  quantumrpg.magicdust.gui:
+    description: Allows to use Magic Dust GUI.
     default: op
     children:
-      quantumrpg.party.cmd.chat: true
-      quantumrpg.party.cmd.create: true
-      quantumrpg.party.cmd.disband: true
-      quantumrpg.party.cmd.drop: true
-      quantumrpg.party.cmd.exp: true
-      quantumrpg.party.cmd.invite: true
-      quantumrpg.party.cmd.join: true
-      quantumrpg.party.cmd.kick: true
-      quantumrpg.party.cmd.leave: true
-      quantumrpg.party.cmd.menu: true
-      quantumrpg.party.cmd.roll: true
-      quantumrpg.party.cmd.tp: true
-      divinity.party.cmd.chat: true
-      divinity.party.cmd.create: true
-      divinity.party.cmd.disband: true
-      divinity.party.cmd.drop: true
-      divinity.party.cmd.exp: true
-      divinity.party.cmd.invite: true
-      divinity.party.cmd.join: true
-      divinity.party.cmd.kick: true
-      divinity.party.cmd.leave: true
-      divinity.party.cmd.menu: true
-      divinity.party.cmd.roll: true
-      divinity.party.cmd.tp: true
-  quantumrpg.party.cmd.chat:
-    description: Access to /party chat command.
-    default: true
-    children:
-      divinity.party.cmd.chat: true
-  quantumrpg.party.cmd.create:
-    description: Access to /party create command.
-    default: true
-    children:
-      divinity.party.cmd.create: true
-  quantumrpg.party.cmd.disband:
-    description: Access to /party disband command.
-    default: true
-    children:
-      divinity.party.cmd.disband: true
-  quantumrpg.party.cmd.drop:
-    description: Access to /party drop command.
-    default: true
-    children:
-      divinity.party.cmd.drop: true
-  quantumrpg.party.cmd.exp:
-    description: Access to /party exp command.
-    default: true
-    children:
-      divinity.party.cmd.exp: true
-  quantumrpg.party.cmd.invite:
-    description: Access to /party invite command.
-    default: true
-    children:
-      divinity.party.cmd.invite: true
-  quantumrpg.party.cmd.join:
-    description: Access to /party join command.
-    default: true
-    children:
-      divinity.party.cmd.join: true
-  quantumrpg.party.cmd.kick:
-    description: Access to /party kick command.
-    default: true
-    children:
-      divinity.party.cmd.kick: true
-  quantumrpg.party.cmd.leave:
-    description: Access to /party leave command.
-    default: true
-    children:
-      divinity.party.cmd.leave: true
-  quantumrpg.party.cmd.menu:
-    description: Access to /party menu command.
-    default: true
-    children:
-      divinity.party.cmd.menu: true
-  quantumrpg.party.cmd.roll:
-    description: Access to /party roll command.
-    default: true
-    children:
-      divinity.party.cmd.roll: true
-  quantumrpg.party.cmd.tp:
-    description: Access to /party tp command.
-    default: true
-    children:
-      divinity.party.cmd.tp: true
+      divinity.magicdust.gui: true
+
+  # Party ----------------------------------------------------
   divinity.party:
     description: Access to Party module.
     default: true
     children:
       divinity.party.cmd: true
+  quantumrpg.party:
+    description: Access to Party module.
+    default: true
+    children:
+      quantumrpg.party.cmd: true
+      divinity.party: true
   divinity.party.cmd:
     description: Access to Party commands.
     default: op
@@ -749,271 +678,359 @@ permissions:
       divinity.party.cmd.menu: true
       divinity.party.cmd.roll: true
       divinity.party.cmd.tp: true
+  quantumrpg.party.cmd:
+    description: Access to Party commands.
+    default: op
+    children:
+      quantumrpg.party.cmd.chat: true
+      quantumrpg.party.cmd.create: true
+      quantumrpg.party.cmd.disband: true
+      quantumrpg.party.cmd.drop: true
+      quantumrpg.party.cmd.exp: true
+      quantumrpg.party.cmd.invite: true
+      quantumrpg.party.cmd.join: true
+      quantumrpg.party.cmd.kick: true
+      quantumrpg.party.cmd.leave: true
+      quantumrpg.party.cmd.menu: true
+      quantumrpg.party.cmd.roll: true
+      quantumrpg.party.cmd.tp: true
+      divinity.party.cmd: true
   divinity.party.cmd.chat:
     description: Access to /party chat command.
     default: true
+  quantumrpg.party.cmd.chat:
+    description: Access to /party chat command.
+    default: true
+    children:
+      divinity.party.cmd.chat: true
   divinity.party.cmd.create:
     description: Access to /party create command.
     default: true
+  quantumrpg.party.cmd.create:
+    description: Access to /party create command.
+    default: true
+    children:
+      divinity.party.cmd.create: true
   divinity.party.cmd.disband:
     description: Access to /party disband command.
     default: true
+  quantumrpg.party.cmd.disband:
+    description: Access to /party disband command.
+    default: true
+    children:
+      divinity.party.cmd.disband: true
   divinity.party.cmd.drop:
     description: Access to /party drop command.
     default: true
+  quantumrpg.party.cmd.drop:
+    description: Access to /party drop command.
+    default: true
+    children:
+      divinity.party.cmd.drop: true
   divinity.party.cmd.exp:
     description: Access to /party exp command.
     default: true
+  quantumrpg.party.cmd.exp:
+    description: Access to /party exp command.
+    default: true
+    children:
+      divinity.party.cmd.exp: true
   divinity.party.cmd.invite:
     description: Access to /party invite command.
     default: true
+  quantumrpg.party.cmd.invite:
+    description: Access to /party invite command.
+    default: true
+    children:
+      divinity.party.cmd.invite: true
   divinity.party.cmd.join:
     description: Access to /party join command.
     default: true
+  quantumrpg.party.cmd.join:
+    description: Access to /party join command.
+    default: true
+    children:
+      divinity.party.cmd.join: true
   divinity.party.cmd.kick:
     description: Access to /party kick command.
     default: true
+  quantumrpg.party.cmd.kick:
+    description: Access to /party kick command.
+    default: true
+    children:
+      divinity.party.cmd.kick: true
   divinity.party.cmd.leave:
     description: Access to /party leave command.
     default: true
+  quantumrpg.party.cmd.leave:
+    description: Access to /party leave command.
+    default: true
+    children:
+      divinity.party.cmd.leave: true
   divinity.party.cmd.menu:
     description: Access to /party menu command.
     default: true
+  quantumrpg.party.cmd.menu:
+    description: Access to /party menu command.
+    default: true
+    children:
+      divinity.party.cmd.menu: true
   divinity.party.cmd.roll:
     description: Access to /party roll command.
     default: true
+  quantumrpg.party.cmd.roll:
+    description: Access to /party roll command.
+    default: true
+    children:
+      divinity.party.cmd.roll: true
   divinity.party.cmd.tp:
     description: Access to /party tp command.
     default: true
+  quantumrpg.party.cmd.tp:
+    description: Access to /party tp command.
+    default: true
+    children:
+      divinity.party.cmd.tp: true
 
   # Refine ----------------------------------------------------
-  quantumrpg.refine:
-    description: Access to Refine module.
-    default: op
-    children:
-      quantumrpg.refine.cmd: true
-      divinity.refine.cmd: true
-  quantumrpg.refine.cmd:
-    description: Access to Refine commands.
-    default: op
-    children:
-      quantumrpg.refine.cmd.refine: true
-      quantumrpg.refine.cmd.downgrade: true
-      divinity.refine.cmd.refine: true
-      divinity.refine.cmd.downgrade: true
-  quantumrpg.refine.cmd.refine:
-    description: Access to /refine refine command.
-    default: op
-    children:
-      divinity.refine.cmd.refine: true
-  quantumrpg.refine.cmd.downgrade:
-    description: Access to /refine downgrade command.
-    default: op
-    children:
-      divinity.refine.cmd.downgrade: true
   divinity.refine:
     description: Access to Refine module.
     default: op
     children:
       divinity.refine.cmd: true
+  quantumrpg.refine:
+    description: Access to Refine module.
+    default: op
+    children:
+      quantumrpg.refine.cmd: true
+      divinity.refine: true
   divinity.refine.cmd:
     description: Access to Refine commands.
     default: op
     children:
       divinity.refine.cmd.refine: true
       divinity.refine.cmd.downgrade: true
+  quantumrpg.refine.cmd:
+    description: Access to Refine commands.
+    default: op
+    children:
+      quantumrpg.refine.cmd.refine: true
+      quantumrpg.refine.cmd.downgrade: true
+      divinity.refine.cmd: true
+  divinity.refine.cmd.refine:
+    description: Access to /refine refine command.
+    default: op
+  quantumrpg.refine.cmd.refine:
+    description: Legacy alias for divinity.refine.cmd.refine.
+    default: op
+    children:
+      divinity.refine.cmd.refine: true
+  divinity.refine.cmd.downgrade:
+    description: Access to /refine downgrade command.
+    default: op
+  quantumrpg.refine.cmd.downgrade:
+    description: Legacy alias for divinity.refine.cmd.downgrade.
+    default: op
+    children:
+      divinity.refine.cmd.downgrade: true
 
   # Repair ----------------------------------------------------
-  quantumrpg.repair:
-    description: Access to Repair module.
-    default: op
-    children:
-      quantumrpg.repair.cmd: true
-      quantumrpg.repair.gui: true
-      divinity.repair.cmd: true
-      divinity.repair.gui: true
-  quantumrpg.repair.cmd:
-    description: Access to Repair commands.
-    default: op
-    children:
-      quantumrpg.repair.cmd.open: true
-      divinity.repair.cmd.open: true
-  quantumrpg.repair.cmd.open:
-    description: Access to /repair open command.
-    default: op
-    children:
-      divinity.repair.cmd.open: true
-  quantumrpg.repair.gui:
-    description: Access to Repair GUI.
-    default: op
-    children:
-      divinity.repair.gui: true
   divinity.repair:
     description: Access to Repair module.
     default: op
     children:
       divinity.repair.cmd: true
       divinity.repair.gui: true
+  quantumrpg.repair:
+    description: Access to Repair module.
+    default: op
+    children:
+      quantumrpg.repair.cmd: true
+      quantumrpg.repair.gui: true
+      divinity.repair: true
   divinity.repair.cmd:
     description: Access to Repair commands.
+    default: op
+    children:
+      divinity.repair.cmd.open: true
+  quantumrpg.repair.cmd:
+    description: Access to Repair commands.
+    default: op
+    children:
+      quantumrpg.repair.cmd.open: true
+      divinity.repair.cmd: true
+  divinity.repair.cmd.open:
+    description: Access to /repair open command.
+    default: op
+  quantumrpg.repair.cmd.open:
+    description: Legacy alias for divinity.repair.cmd.open.
     default: op
     children:
       divinity.repair.cmd.open: true
   divinity.repair.gui:
     description: Access to Repair GUI.
     default: op
+  quantumrpg.repair.gui:
+    description: Access to Repair GUI.
+    default: op
+    children:
+      divinity.repair.gui: true
 
   # Runes ----------------------------------------------------
-  quantumrpg.runes:
-    description: Full access to Runes module.
-    default: op
-    children:
-      quantumrpg.runes.cmd: true
-      quantumrpg.runes.gui: true
-      divinity.runes.cmd: true
-      divinity.runes.gui: true
-  quantumrpg.runes.cmd:
-    description: Access to all Runes commands.
-    default: op
-    children:
-      quantumrpg.runes.cmd.merchant: true
-      quantumrpg.runes.cmd.merchant.others: true
-      divinity.runes.cmd.merchant: true
-      divinity.runes.cmd.merchant.others: true
-  quantumrpg.runes.cmd.merchant:
-    description: Access to /runes merchant command.
-    default: op
-    children:
-      divinity.runes.cmd.merchant: true
-  quantumrpg.runes.cmd.merchant.others:
-    description: Access to /runes merchant [player] command.
-    default: op
-    children:
-      divinity.runes.cmd.merchant.others: true
-  quantumrpg.runes.gui:
-    description: Access to all Runes GUIs.
-    default: op
-    children:
-      quantumrpg.runes.gui.user: true
-      quantumrpg.runes.gui.merchant: true
-      divinity.runes.gui.user: true
-      divinity.runes.gui.merchant: true
-  quantumrpg.runes.gui.user:
-    description: Access to Default Socketing GUI.
-    default: op
-    children:
-      divinity.runes.gui.user: true
-  quantumrpg.runes.gui.merchant:
-    description: Access to Merchant Socketing GUI.
-    default: op
-    children:
-      divinity.runes.gui.merchant: true
   divinity.runes:
     description: Full access to Runes module.
     default: op
     children:
       divinity.runes.cmd: true
       divinity.runes.gui: true
-
+  quantumrpg.runes:
+    description: Full access to Runes module.
+    default: op
+    children:
+      quantumrpg.runes.cmd: true
+      quantumrpg.runes.gui: true
+      divinity.runes: true
   divinity.runes.cmd:
     description: Access to all Runes commands.
     default: op
     children:
       divinity.runes.cmd.merchant: true
       divinity.runes.cmd.merchant.others: true
+  quantumrpg.runes.cmd:
+    description: Access to all Runes commands.
+    default: op
+    children:
+      quantumrpg.runes.cmd.merchant: true
+      quantumrpg.runes.cmd.merchant.others: true
+      divinity.runes.cmd: true
   divinity.runes.cmd.merchant:
     description: Access to /runes merchant command.
     default: op
+  quantumrpg.runes.cmd.merchant:
+    description: Access to /runes merchant command.
+    default: op
+    children:
+      divinity.runes.cmd.merchant: true
   divinity.runes.cmd.merchant.others:
     description: Access to /runes merchant [player] command.
     default: op
-
+  quantumrpg.runes.cmd.merchant.others:
+    description: Access to /runes merchant [player] command.
+    default: op
+    children:
+      divinity.runes.cmd.merchant.others: true
   divinity.runes.gui:
     description: Access to all Runes GUIs.
     default: op
     children:
       divinity.runes.gui.user: true
       divinity.runes.gui.merchant: true
+  quantumrpg.runes.gui:
+    description: Access to all Runes GUIs.
+    default: op
+    children:
+      quantumrpg.runes.gui.user: true
+      quantumrpg.runes.gui.merchant: true
+      divinity.runes.gui: true
   divinity.runes.gui.user:
     description: Access to Default Socketing GUI.
     default: op
+  quantumrpg.runes.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+    children:
+      divinity.runes.gui.user: true
   divinity.runes.gui.merchant:
     description: Access to Merchant Socketing GUI.
     default: op
+  quantumrpg.runes.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      divinity.runes.gui.merchant: true
+
+
 
   # Sell ----------------------------------------------------
-  quantumrpg.sell:
-    description: Full access to the Sell module.
-    default: op
-    children:
-      quantumrpg.sell.cmd: true
-      quantumrpg.sell.gui: true
-      divinity.sell.cmd: true
-      divinity.sell.gui: true
-  quantumrpg.sell.cmd:
-    description: Access to Sell commands.
-    default: op
-    children:
-      quantumrpg.sell.cmd.open: true
-      divinity.sell.cmd.open: true
-  quantumrpg.sell.cmd.open:
-    description: Access to /sell open command.
-    default: op
-    children:
-      divinity.sell.cmd.open: true
-  quantumrpg.sell.gui:
-    description: Access to Sell GUI.
-    default: op
-    children:
-      divinity.sell.gui: true
   divinity.sell:
     description: Full access to the Sell module.
     default: op
     children:
       divinity.sell.cmd: true
       divinity.sell.gui: true
+  quantumrpg.sell:
+    description: Full access to the Sell module.
+    default: op
+    children:
+      quantumrpg.sell.cmd: true
+      quantumrpg.sell.gui: true
+      divinity.sell: true
   divinity.sell.cmd:
     description: Access to Sell commands.
+    default: op
+    children:
+      divinity.sell.cmd.open: true
+  quantumrpg.sell.cmd:
+    description: Access to Sell commands.
+    default: op
+    children:
+      quantumrpg.sell.cmd.open: true
+      divinity.sell.cmd: true
+  divinity.sell.cmd.open:
+    description: Access to /sell open command.
+    default: op
+  quantumrpg.sell.cmd.open:
+    description: Legacy alias for divinity.sell.cmd.open.
     default: op
     children:
       divinity.sell.cmd.open: true
   divinity.sell.gui:
     description: Access to Sell GUI.
     default: op
+  quantumrpg.sell.gui:
+    description: Access to Sell GUI.
+    default: op
+    children:
+      divinity.sell.gui: true
 
   # Soulbound ----------------------------------------------------
+  divinity.soulbound:
+    description: Access to Soulbound module.
+    default: op
+    children:
+      divinity.soulbound.cmd: true
   quantumrpg.soulbound:
     description: Access to Soulbound module.
     default: op
     children:
       quantumrpg.soulbound.cmd: true
-      divinity.soulbound.cmd: true
+      divinity.soulbound: true
+  divinity.soulbound.cmd:
+    description: Access to Soulbound commands.
+    default: op
+    children:
+      divinity.soulbound.cmd.soul: true
+      divinity.soulbound.cmd.untradeable: true
   quantumrpg.soulbound.cmd:
     description: Access to Soulbound commands.
     default: op
     children:
       quantumrpg.soulbound.cmd.soul: true
       quantumrpg.soulbound.cmd.untradeable: true
-      divinity.soulbound.cmd.soul: true
-      divinity.soulbound.cmd.untradeable: true
-  quantumrpg.soulbound.cmd.soul:
+      divinity.soulbound.cmd: true
+  divinity.soulbound.cmd.soul:
     description: Access to /soulbound soul command.
     default: op
+  quantumrpg.soulbound.cmd.soul:
+    description: Legacy alias for divinity.soulbound.cmd.soul.
+    default: op
     children:
       divinity.soulbound.cmd.soul: true
-  quantumrpg.soulbound.cmd.untradeable:
+  divinity.soulbound.cmd.untradeable:
     description: Access to /soulbound untradeable command.
     default: op
-    children:
-      divinity.soulbound.cmd.untradeable: true
-  divinity.soulbound:
-    description: Access to Soulbound module.
+  quantumrpg.soulbound.cmd.untradeable:
+    description: Legacy alias for divinity.soulbound.cmd.untradeable.
     default: op
     children:
-      divinity.soulbound.cmd: true
-  divinity.soulbound.cmd:
-    description: Access to Soulbound commands.
-    default: op
-    children:
-      divinity.soulbound.cmd.soul: true
       divinity.soulbound.cmd.untradeable: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,28 +58,38 @@ permissions:
     description: Bypass all item player requirements.
     default: op
     children:
-      divinity.bypass.class: true
-      divinity.bypass.level: true
-      divinity.bypass.soulbound: true
-      divinity.bypass.untradeable: true
+      quantumrpg.bypass.requirement: true
+      divinity.bypass.requirement.class: true
+      divinity.bypass.requirement.level: true
+      divinity.bypass.requirement.soulbound: true
+      divinity.bypass.requirement.untradeable: true
   divinity.bypass.requirement.level:
     description: Bypass item player level requirement.
     default: op
+    children:
+      quantumrpg.bypass.requirement.level: true
   divinity.bypass.requirement.class:
     description: Bypass item player class requirement.
     default: op
+    children:
+      quantumrpg.bypass.requirement.class: true
   divinity.bypass.requirement.soulbound:
     description: Bypass item player soulbound requirement.
     default: op
+    children:
+      quantumrpg.bypass.requirement.soulbound: true
   divinity.bypass.requirement.untradeable:
     description: Bypass item untradeable requirement.
     default: op
 
+    children:
+      quantumrpg.bypass.requirement.untradeable: true
   # Classes ----------------------------------------------------
   divinity.classes:
     description: Full access to Classes module.
     default: op
     children:
+      quantumrpg.classes: true
       divinity.classes.cmd: true
       divinity.classes.class.*: true
   divinity.classes.cmd:
@@ -93,6 +103,13 @@ permissions:
       divinity.classes.cmd.aspects: true
       divinity.classes.cmd.addexp: true
       divinity.classes.cmd.addlevel: true
+      divinity.classes.cmd.addskill: true
+      divinity.classes.cmd.addaspectpoints: true
+      divinity.classes.cmd.addskillpoints: true
+      divinity.classes.cmd.setclass: true
+      divinity.classes.cmd.reset: true
+      divinity.classes.cmd.resetaspectpoints: true
+      divinity.classes.cmd.resetskillpoints: true
       quantumrpg.classes.cmd.addskill: true
       quantumrpg.classes.cmd.addaspectpoints: true
       quantumrpg.classes.cmd.addskillpoints: true
@@ -100,6 +117,79 @@ permissions:
       quantumrpg.classes.cmd.reset: true
       quantumrpg.classes.cmd.resetaspectpoints: true
       quantumrpg.classes.cmd.resetskillpoints: true
+  divinity.classes.cmd.cast:
+    description: Access to /class cast command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.cast: true
+  divinity.classes.cmd.select:
+    description: Access to /class select command.
+    default: true
+    children:
+      quantumrpg.classes.cmd.select: true
+  divinity.classes.cmd.skills:
+    description: Access to /class skills command.
+    default: true
+    children:
+      quantumrpg.classes.cmd.skills: true
+  divinity.classes.cmd.stats:
+    description: Access to /class stats command.
+    default: true
+    children:
+      quantumrpg.classes.cmd.stats: true
+  divinity.classes.cmd.aspects:
+    description: Access to /class aspects command.
+    default: true
+    children:
+      quantumrpg.classes.cmd.aspects: true
+  divinity.classes.cmd.addexp:
+    description: Access to /class addexp command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.addexp: true
+  divinity.classes.cmd.addlevel:
+    description: Access to /class addlevel command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.addlevel: true
+  divinity.classes.cmd.addskill:
+    description: Access to /class addskill command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.addskill: true
+  divinity.classes.cmd.addaspectpoints:
+    description: Access to /class addaspectpoints command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.addaspectpoints: true
+  divinity.classes.cmd.addskillpoints:
+    description: Access to /class addskillpoints command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.addskillpoints: true
+  divinity.classes.cmd.setclass:
+    description: Access to /class setclass command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.setclass: true
+  divinity.classes.cmd.reset:
+    description: Access to /class reset command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.reset: true
+  divinity.classes.cmd.resetaspectpoints:
+    description: Access to /class resetaspectpoints command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.resetaspectpoints: true
+  divinity.classes.cmd.resetskillpoints:
+    description: Access to /class resetskillpoints command.
+    default: op
+    children:
+      quantumrpg.classes.cmd.resetskillpoints: true
+  divinity.classes.class.*:
+    description: Access to all classes.
+    default: op
   quantumrpg.classes.cmd.cast:
     description: Access to /class cast command.
     default: op
@@ -144,6 +234,23 @@ permissions:
     default: op
 
   # Combat Log ----------------------------------------------------
+  divinity.combatlog:
+    description: Full access to Combat Log module.
+    default: op
+    children:
+      divinity.combatlog.cmd: true
+      quantumrpg.combatlog.cmd: true
+  divinity.combatlog.cmd:
+    description: Access to all Combat Log commands.
+    default: op
+    children:
+      divinity.combatlog.cmd.log: true
+      quantumrpg.combatlog.cmd.log: true
+  divinity.combatlog.cmd.log:
+    description: Access to /combatlog log command.
+    default: true
+    children:
+      quantumrpg.combatlog.cmd.log: true
   quantumrpg.combatlog:
     description: Full access to Combat Log module.
     default: op
@@ -159,6 +266,30 @@ permissions:
     default: true
 
   # Dismantle ----------------------------------------------------
+  divinity.dismantle:
+    description: Full access to the Dismantle module.
+    default: op
+    children:
+      divinity.dismantle.cmd: true
+      divinity.dismantle.gui: true
+      quantumrpg.dismantle.cmd: true
+      quantumrpg.dismantle.gui: true
+  divinity.dismantle.cmd:
+    description: Access to Dismantle commands.
+    default: op
+    children:
+      divinity.dismantle.cmd.open: true
+      quantumrpg.dismantle.cmd.open: true
+  divinity.dismantle.cmd.open:
+    description: Access to /dismantle open command.
+    default: op
+    children:
+      quantumrpg.dismantle.cmd.open: true
+  divinity.dismantle.gui:
+    description: Access to Dismantle GUI.
+    default: op
+    children:
+      quantumrpg.dismantle.gui: true
   quantumrpg.dismantle:
     description: Full access to the Dismantle module.
     default: op
@@ -175,6 +306,50 @@ permissions:
     default: op
 
   # Essences ----------------------------------------------------
+  divinity.essences:
+    description: Full access to Essences module.
+    default: op
+    children:
+      divinity.essences.cmd: true
+      divinity.essences.gui: true
+      quantumrpg.essences.cmd: true
+      quantumrpg.essences.gui: true
+  divinity.essences.cmd:
+    description: Access to all Essences commands.
+    default: op
+    children:
+      divinity.essences.cmd.merchant: true
+      divinity.essences.cmd.merchant.others: true
+      quantumrpg.essences.cmd.merchant: true
+      quantumrpg.essences.cmd.merchant.others: true
+  divinity.essences.cmd.merchant:
+    description: Access to /essences merchant command.
+    default: op
+    children:
+      quantumrpg.essences.cmd.merchant: true
+  divinity.essences.cmd.merchant.others:
+    description: Access to /essences merchant [player] command.
+    default: op
+    children:
+      quantumrpg.essences.cmd.merchant.others: true
+  divinity.essences.gui:
+    description: Access to all Essences GUIs.
+    default: op
+    children:
+      divinity.essences.gui.user: true
+      divinity.essences.gui.merchant: true
+      quantumrpg.essences.gui.user: true
+      quantumrpg.essences.gui.merchant: true
+  divinity.essences.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+    children:
+      quantumrpg.essences.gui.user: true
+  divinity.essences.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      quantumrpg.essences.gui.merchant: true
   quantumrpg.essences:
     description: Full access to Essences module.
     default: op
@@ -209,6 +384,30 @@ permissions:
     default: op
 
   # Extractor ----------------------------------------------------
+  divinity.extractor:
+    description: Full access to Extractor module.
+    default: op
+    children:
+      divinity.extractor.cmd: true
+      divinity.extractor.gui: true
+      quantumrpg.extractor.cmd: true
+      quantumrpg.extractor.gui: true
+  divinity.extractor.cmd:
+    description: Access to all Extractor commands.
+    default: op
+    children:
+      divinity.extractor.cmd.open: true
+      quantumrpg.extractor.cmd.open: true
+  divinity.extractor.cmd.open:
+    description: Access to /extractor open command.
+    default: op
+    children:
+      quantumrpg.extractor.cmd.open: true
+  divinity.extractor.gui:
+    description: Access Extractor GUI.
+    default: op
+    children:
+      quantumrpg.extractor.gui: true
   quantumrpg.extractor:
     description: Full access to Extractor module.
     default: op
@@ -228,6 +427,30 @@ permissions:
     default: op
 
   # Fortify ----------------------------------------------------
+  divinity.fortify:
+    description: Full access to Fortify module.
+    default: op
+    children:
+      divinity.fortify.cmd: true
+      quantumrpg.fortify.cmd: true
+  divinity.fortify.cmd:
+    description: Access to all Fortify commands.
+    default: op
+    children:
+      divinity.fortify.cmd.fortify: true
+      divinity.fortify.cmd.unfortify: true
+      quantumrpg.fortify.cmd.fortify: true
+      quantumrpg.fortify.cmd.unfortify: true
+  divinity.fortify.cmd.fortify:
+    description: Access to /fortify fortify command.
+    default: op
+    children:
+      quantumrpg.fortify.cmd.fortify: true
+  divinity.fortify.cmd.unfortify:
+    description: Access to /fortify unfortify command.
+    default: op
+    children:
+      quantumrpg.fortify.cmd.unfortify: true
   quantumrpg.fortify:
     description: Full access to Fortify module.
     default: op
@@ -247,6 +470,50 @@ permissions:
     default: op
 
   # Gems ----------------------------------------------------
+  divinity.gems:
+    description: Full access to Gems module.
+    default: op
+    children:
+      divinity.gems.cmd: true
+      divinity.gems.gui: true
+      quantumrpg.gems.cmd: true
+      quantumrpg.gems.gui: true
+  divinity.gems.cmd:
+    description: Access to all Gems commands.
+    default: op
+    children:
+      divinity.gems.cmd.merchant: true
+      divinity.gems.cmd.merchant.others: true
+      quantumrpg.gems.cmd.merchant: true
+      quantumrpg.gems.cmd.merchant.others: true
+  divinity.gems.cmd.merchant:
+    description: Access to /gems merchant command.
+    default: op
+    children:
+      quantumrpg.gems.cmd.merchant: true
+  divinity.gems.cmd.merchant.others:
+    description: Access to /gems merchant [player] command.
+    default: op
+    children:
+      quantumrpg.gems.cmd.merchant.others: true
+  divinity.gems.gui:
+    description: Access to all Gems GUIs.
+    default: op
+    children:
+      divinity.gems.gui.user: true
+      divinity.gems.gui.merchant: true
+      quantumrpg.gems.gui.user: true
+      quantumrpg.gems.gui.merchant: true
+  divinity.gems.gui.user:
+    description: Access to user socketing GUI.
+    default: op
+    children:
+      quantumrpg.gems.gui.user: true
+  divinity.gems.gui.merchant:
+    description: Access to Merchant socketing GUI.
+    default: op
+    children:
+      quantumrpg.gems.gui.merchant: true
   quantumrpg.gems:
     description: Full access to Gems module.
     default: op
@@ -279,6 +546,23 @@ permissions:
     default: op
 
   # Identify ----------------------------------------------------
+  divinity.identify:
+    description: Full access to Identify module.
+    default: op
+    children:
+      divinity.identify.cmd: true
+      quantumrpg.identify.cmd: true
+  divinity.identify.cmd:
+    description: Access to all Identify commands.
+    default: op
+    children:
+      divinity.identify.cmd.identify: true
+      quantumrpg.identify.cmd.identify: true
+  divinity.identify.cmd.identify:
+    description: Access to /identify identify command.
+    default: op
+    children:
+      quantumrpg.identify.cmd.identify: true
   quantumrpg.identify:
     description: Full access to Identify module.
     default: op
@@ -294,6 +578,30 @@ permissions:
     default: op
 
   # Magic Dust ----------------------------------------------------
+  divinity.magicdust:
+    description: Full access to Magic Dust module.
+    default: op
+    children:
+      divinity.magicdust.cmd: true
+      divinity.magicdust.gui: true
+      quantumrpg.magicdust.cmd: true
+      quantumrpg.magicdust.gui: true
+  divinity.magicdust.cmd:
+    description: Full access to Magic Dust commands.
+    default: op
+    children:
+      divinity.magicdust.cmd.open: true
+      quantumrpg.magicdust.cmd.open: true
+  divinity.magicdust.cmd.open:
+    description: Allows to use /magicdust open command.
+    default: op
+    children:
+      quantumrpg.magicdust.cmd.open: true
+  divinity.magicdust.gui:
+    description: Allows to use Magic Dust GUI.
+    default: op
+    children:
+      quantumrpg.magicdust.gui: true
   quantumrpg.magicdust:
     description: Full access to Magic Dust module.
     default: op
@@ -313,6 +621,100 @@ permissions:
     default: op
 
   # Party ----------------------------------------------------
+  divinity.party:
+    description: Access to Party module.
+    default: true
+    children:
+      divinity.party.cmd: true
+      quantumrpg.party.cmd: true
+  divinity.party.cmd:
+    description: Access to Party commands.
+    default: op
+    children:
+      divinity.party.cmd.chat: true
+      divinity.party.cmd.create: true
+      divinity.party.cmd.disband: true
+      divinity.party.cmd.drop: true
+      divinity.party.cmd.exp: true
+      divinity.party.cmd.invite: true
+      divinity.party.cmd.join: true
+      divinity.party.cmd.kick: true
+      divinity.party.cmd.leave: true
+      divinity.party.cmd.menu: true
+      divinity.party.cmd.roll: true
+      divinity.party.cmd.tp: true
+      quantumrpg.party.cmd.chat: true
+      quantumrpg.party.cmd.create: true
+      quantumrpg.party.cmd.disband: true
+      quantumrpg.party.cmd.drop: true
+      quantumrpg.party.cmd.exp: true
+      quantumrpg.party.cmd.invite: true
+      quantumrpg.party.cmd.join: true
+      quantumrpg.party.cmd.kick: true
+      quantumrpg.party.cmd.leave: true
+      quantumrpg.party.cmd.menu: true
+      quantumrpg.party.cmd.roll: true
+      quantumrpg.party.cmd.tp: true
+  divinity.party.cmd.chat:
+    description: Access to /party chat command.
+    default: true
+    children:
+      quantumrpg.party.cmd.chat: true
+  divinity.party.cmd.create:
+    description: Access to /party create command.
+    default: true
+    children:
+      quantumrpg.party.cmd.create: true
+  divinity.party.cmd.disband:
+    description: Access to /party disband command.
+    default: true
+    children:
+      quantumrpg.party.cmd.disband: true
+  divinity.party.cmd.drop:
+    description: Access to /party drop command.
+    default: true
+    children:
+      quantumrpg.party.cmd.drop: true
+  divinity.party.cmd.exp:
+    description: Access to /party exp command.
+    default: true
+    children:
+      quantumrpg.party.cmd.exp: true
+  divinity.party.cmd.invite:
+    description: Access to /party invite command.
+    default: true
+    children:
+      quantumrpg.party.cmd.invite: true
+  divinity.party.cmd.join:
+    description: Access to /party join command.
+    default: true
+    children:
+      quantumrpg.party.cmd.join: true
+  divinity.party.cmd.kick:
+    description: Access to /party kick command.
+    default: true
+    children:
+      quantumrpg.party.cmd.kick: true
+  divinity.party.cmd.leave:
+    description: Access to /party leave command.
+    default: true
+    children:
+      quantumrpg.party.cmd.leave: true
+  divinity.party.cmd.menu:
+    description: Access to /party menu command.
+    default: true
+    children:
+      quantumrpg.party.cmd.menu: true
+  divinity.party.cmd.roll:
+    description: Access to /party roll command.
+    default: true
+    children:
+      quantumrpg.party.cmd.roll: true
+  divinity.party.cmd.tp:
+    description: Access to /party tp command.
+    default: true
+    children:
+      quantumrpg.party.cmd.tp: true
   quantumrpg.party:
     description: Access to Party module.
     default: true
@@ -372,6 +774,30 @@ permissions:
     default: true
 
   # Refine ----------------------------------------------------
+  divinity.refine:
+    description: Access to Refine module.
+    default: op
+    children:
+      divinity.refine.cmd: true
+      quantumrpg.refine.cmd: true
+  divinity.refine.cmd:
+    description: Access to Refine commands.
+    default: op
+    children:
+      divinity.refine.cmd.refine: true
+      divinity.refine.cmd.downgrade: true
+      quantumrpg.refine.cmd.refine: true
+      quantumrpg.refine.cmd.downgrade: true
+  divinity.refine.cmd.refine:
+    description: Access to /refine refine command.
+    default: op
+    children:
+      quantumrpg.refine.cmd.refine: true
+  divinity.refine.cmd.downgrade:
+    description: Access to /refine downgrade command.
+    default: op
+    children:
+      quantumrpg.refine.cmd.downgrade: true
   quantumrpg.refine:
     description: Access to Refine module.
     default: op
@@ -385,6 +811,30 @@ permissions:
       quantumrpg.refine.cmd.downgrade: true
 
   # Repair ----------------------------------------------------
+  divinity.repair:
+    description: Access to Repair module.
+    default: op
+    children:
+      divinity.repair.cmd: true
+      divinity.repair.gui: true
+      quantumrpg.repair.cmd: true
+      quantumrpg.repair.gui: true
+  divinity.repair.cmd:
+    description: Access to Repair commands.
+    default: op
+    children:
+      divinity.repair.cmd.open: true
+      quantumrpg.repair.cmd.open: true
+  divinity.repair.cmd.open:
+    description: Access to /repair open command.
+    default: op
+    children:
+      quantumrpg.repair.cmd.open: true
+  divinity.repair.gui:
+    description: Access to Repair GUI.
+    default: op
+    children:
+      quantumrpg.repair.gui: true
   quantumrpg.repair:
     description: Access to Repair module.
     default: op
@@ -401,6 +851,50 @@ permissions:
     default: op
 
   # Runes ----------------------------------------------------
+  divinity.runes:
+    description: Full access to Runes module.
+    default: op
+    children:
+      divinity.runes.cmd: true
+      divinity.runes.gui: true
+      quantumrpg.runes.cmd: true
+      quantumrpg.runes.gui: true
+  divinity.runes.cmd:
+    description: Access to all Runes commands.
+    default: op
+    children:
+      divinity.runes.cmd.merchant: true
+      divinity.runes.cmd.merchant.others: true
+      quantumrpg.runes.cmd.merchant: true
+      quantumrpg.runes.cmd.merchant.others: true
+  divinity.runes.cmd.merchant:
+    description: Access to /runes merchant command.
+    default: op
+    children:
+      quantumrpg.runes.cmd.merchant: true
+  divinity.runes.cmd.merchant.others:
+    description: Access to /runes merchant [player] command.
+    default: op
+    children:
+      quantumrpg.runes.cmd.merchant.others: true
+  divinity.runes.gui:
+    description: Access to all Runes GUIs.
+    default: op
+    children:
+      divinity.runes.gui.user: true
+      divinity.runes.gui.merchant: true
+      quantumrpg.runes.gui.user: true
+      quantumrpg.runes.gui.merchant: true
+  divinity.runes.gui.user:
+    description: Access to Default Socketing GUI.
+    default: op
+    children:
+      quantumrpg.runes.gui.user: true
+  divinity.runes.gui.merchant:
+    description: Access to Merchant Socketing GUI.
+    default: op
+    children:
+      quantumrpg.runes.gui.merchant: true
   quantumrpg.runes:
     description: Full access to Runes module.
     default: op
@@ -435,6 +929,30 @@ permissions:
     default: op
 
   # Sell ----------------------------------------------------
+  divinity.sell:
+    description: Full access to the Sell module.
+    default: op
+    children:
+      divinity.sell.cmd: true
+      divinity.sell.gui: true
+      quantumrpg.sell.cmd: true
+      quantumrpg.sell.gui: true
+  divinity.sell.cmd:
+    description: Access to Sell commands.
+    default: op
+    children:
+      divinity.sell.cmd.open: true
+      quantumrpg.sell.cmd.open: true
+  divinity.sell.cmd.open:
+    description: Access to /sell open command.
+    default: op
+    children:
+      quantumrpg.sell.cmd.open: true
+  divinity.sell.gui:
+    description: Access to Sell GUI.
+    default: op
+    children:
+      quantumrpg.sell.gui: true
   quantumrpg.sell:
     description: Full access to the Sell module.
     default: op
@@ -451,6 +969,30 @@ permissions:
     default: op
 
   # Soulbound ----------------------------------------------------
+  divinity.soulbound:
+    description: Access to Soulbound module.
+    default: op
+    children:
+      divinity.soulbound.cmd: true
+      quantumrpg.soulbound.cmd: true
+  divinity.soulbound.cmd:
+    description: Access to Soulbound commands.
+    default: op
+    children:
+      divinity.soulbound.cmd.soul: true
+      divinity.soulbound.cmd.untradeable: true
+      quantumrpg.soulbound.cmd.soul: true
+      quantumrpg.soulbound.cmd.untradeable: true
+  divinity.soulbound.cmd.soul:
+    description: Access to /soulbound soul command.
+    default: op
+    children:
+      quantumrpg.soulbound.cmd.soul: true
+  divinity.soulbound.cmd.untradeable:
+    description: Access to /soulbound untradeable command.
+    default: op
+    children:
+      quantumrpg.soulbound.cmd.untradeable: true
   quantumrpg.soulbound:
     description: Access to Soulbound module.
     default: op

--- a/src/test/java/studio/magemonkey/divinity/PermsAliasTest.java
+++ b/src/test/java/studio/magemonkey/divinity/PermsAliasTest.java
@@ -1,0 +1,85 @@
+package studio.magemonkey.divinity;
+
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import studio.magemonkey.divinity.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for plugin.yml's permission alias graph. Perms.PREFIX resolves to
+ * divinity.* nodes, which the Java code checks directly with plain hasPermission() calls
+ * (no runtime shim). Backward compatibility for servers still granting the legacy
+ * quantumrpg.* nodes relies entirely on plugin.yml's `children` links making a granted
+ * quantumrpg.* node imply the corresponding divinity.* node. These tests exercise that
+ * alias graph through Bukkit's real permission resolution (via MockBukkit), rather than
+ * just asserting against the YAML structure.
+ */
+class PermsAliasTest extends MockedTest {
+
+    private PlayerMock grantedOnly(String permission) {
+        PlayerMock player = genPlayer("perm-test-" + permission.replace('.', '_'), false);
+        player.addAttachment(plugin).setPermission(permission, true);
+        return player;
+    }
+
+    @Test
+    void legacyDismantleGuiGrant_impliesDivinityDismantleGui() {
+        PlayerMock player = grantedOnly("quantumrpg.dismantle.gui");
+        assertTrue(player.hasPermission("divinity.dismantle.gui"));
+    }
+
+    @Test
+    void legacySellGuiGrant_impliesDivinitySellGui() {
+        PlayerMock player = grantedOnly("quantumrpg.sell.gui");
+        assertTrue(player.hasPermission("divinity.sell.gui"));
+    }
+
+    @Test
+    void legacyEssencesGuiUserGrant_impliesDivinityEssencesGuiUser() {
+        PlayerMock player = grantedOnly("quantumrpg.essences.gui.user");
+        assertTrue(player.hasPermission("divinity.essences.gui.user"));
+    }
+
+    @Test
+    void legacyEssencesCmdMerchantOthersGrant_impliesDivinityEquivalent() {
+        PlayerMock player = grantedOnly("quantumrpg.essences.cmd.merchant.others");
+        assertTrue(player.hasPermission("divinity.essences.cmd.merchant.others"));
+    }
+
+    @Test
+    void legacyBypassUntradeableGrant_impliesDivinityEquivalent() {
+        PlayerMock player = grantedOnly("quantumrpg.bypass.requirement.untradeable");
+        assertTrue(player.hasPermission("divinity.bypass.requirement.untradeable"));
+    }
+
+    @Test
+    void legacyAdminGrant_cascadesToDivinityAdminAndDescendants() {
+        PlayerMock player = grantedOnly("quantumrpg.admin");
+        assertTrue(player.hasPermission("divinity.admin"));
+        // divinity.admin's children should still cascade from a legacy grant.
+        assertTrue(player.hasPermission("divinity.dismantle.gui"));
+        assertTrue(player.hasPermission("divinity.bypass.requirement.untradeable"));
+    }
+
+    @Test
+    void legacyUserGrant_impliesDivinityUser() {
+        PlayerMock player = grantedOnly("quantumrpg.user");
+        assertTrue(player.hasPermission("divinity.user"));
+    }
+
+    @Test
+    void noGrant_doesNotImplyEitherNamespace() {
+        PlayerMock player = genPlayer("perm-test-none", false);
+        assertFalse(player.hasPermission("divinity.dismantle.gui"));
+        assertFalse(player.hasPermission("quantumrpg.dismantle.gui"));
+    }
+
+    @Test
+    void opPlayer_getsDivinityPermissionsByDefault() {
+        PlayerMock op = genPlayer("perm-test-op", true);
+        assertTrue(op.hasPermission("divinity.dismantle.gui"));
+        assertTrue(op.hasPermission("divinity.admin"));
+    }
+}

--- a/src/test/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClassPermissionTest.java
+++ b/src/test/java/studio/magemonkey/divinity/modules/list/classes/api/RPGClassPermissionTest.java
@@ -1,0 +1,57 @@
+package studio.magemonkey.divinity.modules.list.classes.api;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import studio.magemonkey.codex.config.api.JYML;
+import studio.magemonkey.divinity.testutil.MockedTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for RPGClass's per-class permission check. Unlike every other permission
+ * node in the plugin, this one is keyed by a user-defined class ID, so plugin.yml can't
+ * statically alias divinity.classes.class.<id> to quantumrpg.classes.class.<id> (the ID space
+ * is unbounded). RPGClass.hasPermission() instead does a two-way runtime check.
+ */
+class RPGClassPermissionTest extends MockedTest {
+
+    private RPGClass newPermissionRequiredClass(String id) throws IOException, InvalidConfigurationException {
+        java.io.File file = Files.createTempDirectory("rpgclass-test").resolve(id + ".yml").toFile();
+        JYML cfg = new JYML(file);
+        cfg.set("name", id);
+        cfg.set("permission-required", true);
+        cfg.set("leveling.max-level", 0);
+        return new RPGClass(plugin, cfg);
+    }
+
+    @Test
+    void divinityGrant_satisfiesPermissionCheck() throws Exception {
+        RPGClass rpgClass = newPermissionRequiredClass("mage");
+        PlayerMock player = genPlayer("class-test-divinity", false);
+        player.addAttachment(plugin).setPermission("divinity.classes.class.mage", true);
+
+        assertTrue(rpgClass.hasPermission(player));
+    }
+
+    @Test
+    void legacyQuantumrpgGrant_satisfiesPermissionCheck() throws Exception {
+        RPGClass rpgClass = newPermissionRequiredClass("warrior");
+        PlayerMock player = genPlayer("class-test-legacy", false);
+        player.addAttachment(plugin).setPermission("quantumrpg.classes.class.warrior", true);
+
+        assertTrue(rpgClass.hasPermission(player));
+    }
+
+    @Test
+    void noGrant_failsPermissionCheck() throws Exception {
+        RPGClass rpgClass = newPermissionRequiredClass("rogue");
+        PlayerMock player = genPlayer("class-test-none", false);
+
+        assertFalse(rpgClass.hasPermission(player));
+    }
+}


### PR DESCRIPTION
Split out of #320 (piece 1/12, independent).

`Perms.has()` accepted both the `quantumrpg.*` and `divinity.*` namespaces as equivalent. This replaces all call sites with plain `Permissible#hasPermission()` checks, and makes `divinity.*` the canonical namespace going forward: `Perms.PREFIX` now builds `divinity.*` nodes instead of `quantumrpg.*` ones.

## Backward compatibility

plugin.yml's alias direction is flipped to match: every `divinity.*` node is now fully self-contained (its `children` only ever reference other `divinity.*` nodes), and every `quantumrpg.*` node carries a link to its `divinity.*` peer via Bukkit's native permission `children` mechanism. Granting a `quantumrpg.*` node still implies the corresponding `divinity.*` node, so any server whose permission plugin grants the legacy `quantumrpg.*` nodes directly keeps working with zero config changes required.

This also adds `quantumrpg.admin`/`quantumrpg.user`/`quantumrpg.bypass`/`quantumrpg.classes` (and a few nested nodes) as new pure-alias nodes, which never existed as real, standalone permissions before this PR — they previously only appeared as inert children-target strings with no declaration of their own, or (for admin/user) relied on Bukkit's "unregistered permission defaults to `isOp()`" behavior. An explicit legacy grant of any of these now correctly cascades to its `divinity.*` equivalent.

The plugin.yml rewrite was verified with a script asserting the whole graph is acyclic and that every `quantumrpg.*` node resolves to its `divinity.*` peer, since an accidental bidirectional link risks a `StackOverflowError` in Bukkit's permission recalculation.

### Known exception: per-class permissions

`RPGClass.hasPermission()` checks a permission keyed by user-defined RPG class IDs (`divinity.classes.class.<id>`), which plugin.yml cannot statically alias since the set of IDs is unbounded and config-defined. This one call site keeps a narrow two-line fallback (checks `divinity.classes.class.<id>` first, `quantumrpg.classes.class.<id>` second) instead of the removed generic shim, since static aliasing structurally can't cover it.

## Tests

Added `PermsAliasTest` and `RPGClassPermissionTest`, which exercise the real permission graph through MockBukkit (not a reimplementation of Bukkit's permission resolution): granting a legacy `quantumrpg.*` node is asserted to imply the corresponding `divinity.*` node for representative nodes across several modules, the `divinity.admin`/`quantumrpg.admin` cascade, OP defaults, and both directions of the per-class fallback in `RPGClass`.

No behavior change for servers already using `quantumrpg.*` or `divinity.*` permissions as before; only servers relying on very specific edge-case grants (e.g. a bare `quantumrpg.admin` grant, or a per-class `quantumrpg.classes.class.<id>` grant) benefit from the newly-added backward-compat paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)