### PR TITLE
Simplify item ID resolution to drop module-prefixed lookup

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
@@ -18,9 +18,12 @@ import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.modules.list.itemgenerator.ItemGeneratorManager;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class DivinityProvider implements ICodexItemProvider<DivinityProvider.DivinityItemType> {
     public static final String NAMESPACE = "DIVINITY";
@@ -82,12 +85,23 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
             IModule<?> module = Divinity.getInstance().getModuleManager().getModule(split[0]);
             if (!(module instanceof QModuleDrop)) return null;
             moduleItem = ((QModuleDrop<?>) module).getItemById(split[1]);
-        } else { // Look in all modules
+        } else { // Look in all modules; require the id to be unambiguous
+            List<IModule<?>> matches = new ArrayList<>();
             for (IModule<?> module : Divinity.getInstance().getModuleManager().getModules()) {
                 if (!(module instanceof QModuleDrop)) continue;
 
-                moduleItem = ((QModuleDrop<? extends ModuleItem>) module).getItemById(id);
-                if (moduleItem != null) break;
+                ModuleItem candidate = ((QModuleDrop<? extends ModuleItem>) module).getItemById(id);
+                if (candidate != null) {
+                    matches.add(module);
+                    moduleItem = candidate;
+                }
+            }
+
+            if (matches.size() > 1) {
+                Codex.error("Ambiguous Divinity item id '" + id + "' found in multiple modules ("
+                        + matches.stream().map(IModule::getId).collect(Collectors.joining(", "))
+                        + "). Refer to it as '<module>:" + id + "' to disambiguate.");
+                return null;
             }
         }
 
@@ -101,6 +115,10 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
     public DivinityProvider.DivinityItemType getItem(ItemStack itemStack) {
         String id = ItemStats.getId(itemStack);
         if (id == null) return null;
+        QModuleDrop<?> module = ItemStats.getModule(itemStack);
+        if (module != null) {
+            id = module.getId() + ":" + id;
+        }
         return getItem(id);
     }
 

--- a/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
@@ -114,7 +114,15 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
         id = PrefixHelper.stripPrefix(NAMESPACE, id);
 
         String itemId = ItemStats.getId(item);
-        return itemId != null && itemId.equals(id);
+        if (itemId == null) return false;
+        if (itemId.equals(id)) return true;
+
+        // Backward compatibility: older callers may still pass the legacy
+        // "module:id" namespaced form this method used to require.
+        String[] split = id.split(":", 2);
+        if (split.length < 2) return false;
+        QModuleDrop<?> module = ItemStats.getModule(item);
+        return module != null && module.getId().equalsIgnoreCase(split[0]) && itemId.equals(split[1]);
     }
 
     public static class DivinityItemType extends ItemType {

--- a/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
@@ -18,8 +18,8 @@ import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.modules.list.itemgenerator.ItemGeneratorManager;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -86,28 +86,37 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
             if (!(module instanceof QModuleDrop)) return null;
             moduleItem = ((QModuleDrop<?>) module).getItemById(split[1]);
         } else { // Look in all modules; require the id to be unambiguous
-            List<IModule<?>> matches = new ArrayList<>();
-            for (IModule<?> module : Divinity.getInstance().getModuleManager().getModules()) {
-                if (!(module instanceof QModuleDrop)) continue;
-
-                ModuleItem candidate = ((QModuleDrop<? extends ModuleItem>) module).getItemById(id);
-                if (candidate != null) {
-                    matches.add(module);
-                    moduleItem = candidate;
-                }
-            }
+            Map<IModule<?>, ModuleItem> matches = findModuleItemsById(id);
 
             if (matches.size() > 1) {
                 Codex.error("Ambiguous Divinity item id '" + id + "' found in multiple modules ("
-                        + matches.stream().map(IModule::getId).collect(Collectors.joining(", "))
+                        + matches.keySet().stream().map(IModule::getId).collect(Collectors.joining(", "))
                         + "). Refer to it as '<module>:" + id + "' to disambiguate.");
                 return null;
+            }
+
+            if (!matches.isEmpty()) {
+                moduleItem = matches.values().iterator().next();
             }
         }
 
         if (moduleItem != null) return new DivinityItemType(moduleItem, level, material);
 
         return null;
+    }
+
+    /**
+     * Finds every module that has an item registered under the given plain id.
+     */
+    private static Map<IModule<?>, ModuleItem> findModuleItemsById(String id) {
+        Map<IModule<?>, ModuleItem> matches = new LinkedHashMap<>();
+        for (IModule<?> module : Divinity.getInstance().getModuleManager().getModules()) {
+            if (!(module instanceof QModuleDrop)) continue;
+
+            ModuleItem candidate = ((QModuleDrop<? extends ModuleItem>) module).getItemById(id);
+            if (candidate != null) matches.put(module, candidate);
+        }
+        return matches;
     }
 
     @Override
@@ -172,7 +181,11 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
 
         @Override
         public String getID() {
-            return this.moduleItem.getId();
+            String id = this.moduleItem.getId();
+            if (findModuleItemsById(id).size() > 1) {
+                return this.moduleItem.getModule().getId() + ":" + id;
+            }
+            return id;
         }
 
         @Override

--- a/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/DivinityProvider.java
@@ -101,10 +101,6 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
     public DivinityProvider.DivinityItemType getItem(ItemStack itemStack) {
         String id = ItemStats.getId(itemStack);
         if (id == null) return null;
-        QModuleDrop<?> module = ItemStats.getModule(itemStack);
-        if (module != null) {
-            id = module.getId() + ":" + id;
-        }
         return getItem(id);
     }
 
@@ -118,15 +114,7 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
         id = PrefixHelper.stripPrefix(NAMESPACE, id);
 
         String itemId = ItemStats.getId(item);
-        if (itemId == null) return false;
-
-        String[] split = id.split(":", 2);
-        if (split.length < 2) {
-            return itemId.equals(id);
-        }
-
-        QModuleDrop<?> module = ItemStats.getModule(item);
-        return module != null && module.getId().equalsIgnoreCase(split[0]) && itemId.equals(split[1]);
+        return itemId != null && itemId.equals(id);
     }
 
     public static class DivinityItemType extends ItemType {
@@ -158,7 +146,7 @@ public class DivinityProvider implements ICodexItemProvider<DivinityProvider.Div
 
         @Override
         public String getID() {
-            return this.moduleItem.getModule().getId() + ":" + this.moduleItem.getId();
+            return this.moduleItem.getId();
         }
 
         @Override

--- a/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
+++ b/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
@@ -5,17 +5,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-import org.bukkit.inventory.ItemStack;
 import studio.magemonkey.codex.Codex;
 import studio.magemonkey.codex.CodexEngine;
 import studio.magemonkey.codex.items.CodexItemManager;
 import studio.magemonkey.codex.modules.ModuleManager;
 import studio.magemonkey.divinity.Divinity;
-import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.modules.list.arrows.ArrowManager;
 import studio.magemonkey.divinity.modules.list.customitems.CustomItemsManager;
 import studio.magemonkey.divinity.modules.list.itemgenerator.ItemGeneratorManager;
-import studio.magemonkey.divinity.stats.items.ItemStats;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -63,11 +60,9 @@ class DivinityProviderTest {
         itemGenModule = spy(new ItemGeneratorManager(divinity));
         when(moduleManager.getModule("item_generator")).thenReturn(itemGenModule);
         when(moduleManager.getModules()).thenReturn(List.of(arrowModule, itemGenModule));
-        doReturn("item_generator").when(itemGenModule).getId();
 
         customItemsModule = spy(new CustomItemsManager(divinity));
         when(moduleManager.getModule("custom_items")).thenReturn(customItemsModule);
-        doReturn("custom_items").when(customItemsModule).getId();
 
         //noinspection unchecked
         when(divinity.getModuleManager()).thenReturn(moduleManager);
@@ -83,8 +78,6 @@ class DivinityProviderTest {
     void getItem_usesLevel() {
         ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
         doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
-        when(generatorItem.getId()).thenReturn("foobar");
-        doReturn((QModuleDrop<?>) itemGenModule).when(generatorItem).getModule();
 
         DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_item_generator:foobar~level:5");
 
@@ -100,8 +93,6 @@ class DivinityProviderTest {
     void getItem_usesMaterial() {
         ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
         doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
-        when(generatorItem.getId()).thenReturn("foobar");
-        doReturn((QModuleDrop<?>) itemGenModule).when(generatorItem).getModule();
 
         DivinityProvider.DivinityItemType item =
                 provider.getItem("DIVINITY_item_generator:foobar~material:VANILLA_DIAMOND");
@@ -119,8 +110,6 @@ class DivinityProviderTest {
     void getItem_noModule_returnsItem() {
         ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
         doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
-        when(generatorItem.getId()).thenReturn("foobar");
-        doReturn((QModuleDrop<?>) itemGenModule).when(generatorItem).getModule();
 
         DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_foobar");
 
@@ -136,8 +125,6 @@ class DivinityProviderTest {
     void getItem_customItems_returnsItem() {
         CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
         doReturn(codexItem).when(customItemsModule).getItemById("foobar");
-        when(codexItem.getId()).thenReturn("foobar");
-        doReturn((QModuleDrop<?>) customItemsModule).when(codexItem).getModule();
 
         DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_custom_items:foobar");
 
@@ -147,41 +134,5 @@ class DivinityProviderTest {
         assertNull(item.getMaterial());
         assertEquals(codexItem, item.getModuleItem());
         assertInstanceOf(DivinityProvider.DivinityItemType.class, item);
-    }
-
-    @Test
-    void getItem_namespacedIdIncludesModule() {
-        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
-        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
-        when(codexItem.getId()).thenReturn("foobar");
-        doReturn((QModuleDrop<?>) customItemsModule).when(codexItem).getModule();
-
-        DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_custom_items:foobar");
-
-        assertNotNull(item);
-        assertEquals("DIVINITY_custom_items:foobar", item.getNamespacedID());
-    }
-
-    @Test
-    void getItem_itemStackUsesStoredModule() {
-        ItemStack itemStack = mock(ItemStack.class);
-
-        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
-        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
-
-        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
-        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
-
-        try (MockedStatic<ItemStats> itemStats = mockStatic(ItemStats.class)) {
-            itemStats.when(() -> ItemStats.getId(itemStack)).thenReturn("foobar");
-            itemStats.when(() -> ItemStats.getModule(itemStack)).thenReturn(customItemsModule);
-
-            DivinityProvider.DivinityItemType item = provider.getItem(itemStack);
-
-            assertNotNull(item);
-            assertEquals(codexItem, item.getModuleItem());
-            verify(customItemsModule).getItemById("foobar");
-            verify(itemGenModule, never()).getItemById("foobar");
-        }
     }
 }

--- a/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
+++ b/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
@@ -208,4 +208,32 @@ class DivinityProviderTest {
         assertNotNull(item);
         assertEquals(codexItem, item.getModuleItem());
     }
+
+    @Test
+    void getID_uniqueId_returnsBareId() {
+        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
+        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
+        when(codexItem.getId()).thenReturn("foobar");
+
+        DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_custom_items:foobar");
+
+        assertNotNull(item);
+        assertEquals("foobar", item.getID());
+    }
+
+    @Test
+    void getID_ambiguousId_returnsModulePrefixedId() {
+        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
+        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
+
+        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
+        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
+        when(codexItem.getId()).thenReturn("foobar");
+        doReturn(customItemsModule).when(codexItem).getModule();
+
+        DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_custom_items:foobar");
+
+        assertNotNull(item);
+        assertEquals("custom_items:foobar", item.getID());
+    }
 }

--- a/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
+++ b/src/test/java/studio/magemonkey/divinity/utils/DivinityProviderTest.java
@@ -1,6 +1,7 @@
 package studio.magemonkey.divinity.utils;
 
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import studio.magemonkey.divinity.Divinity;
 import studio.magemonkey.divinity.modules.list.arrows.ArrowManager;
 import studio.magemonkey.divinity.modules.list.customitems.CustomItemsManager;
 import studio.magemonkey.divinity.modules.list.itemgenerator.ItemGeneratorManager;
+import studio.magemonkey.divinity.stats.items.ItemStats;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -59,10 +61,13 @@ class DivinityProviderTest {
 
         itemGenModule = spy(new ItemGeneratorManager(divinity));
         when(moduleManager.getModule("item_generator")).thenReturn(itemGenModule);
-        when(moduleManager.getModules()).thenReturn(List.of(arrowModule, itemGenModule));
+        doReturn("item_generator").when(itemGenModule).getId();
 
         customItemsModule = spy(new CustomItemsManager(divinity));
         when(moduleManager.getModule("custom_items")).thenReturn(customItemsModule);
+        doReturn("custom_items").when(customItemsModule).getId();
+
+        when(moduleManager.getModules()).thenReturn(List.of(arrowModule, itemGenModule, customItemsModule));
 
         //noinspection unchecked
         when(divinity.getModuleManager()).thenReturn(moduleManager);
@@ -134,5 +139,73 @@ class DivinityProviderTest {
         assertNull(item.getMaterial());
         assertEquals(codexItem, item.getModuleItem());
         assertInstanceOf(DivinityProvider.DivinityItemType.class, item);
+    }
+
+    @Test
+    void getItem_itemStackUsesStoredModule() {
+        ItemStack itemStack = mock(ItemStack.class);
+
+        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
+        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
+
+        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
+        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
+
+        try (MockedStatic<ItemStats> itemStats = mockStatic(ItemStats.class)) {
+            itemStats.when(() -> ItemStats.getId(itemStack)).thenReturn("foobar");
+            itemStats.when(() -> ItemStats.getModule(itemStack)).thenReturn(customItemsModule);
+
+            DivinityProvider.DivinityItemType item = provider.getItem(itemStack);
+
+            assertNotNull(item);
+            assertEquals(codexItem, item.getModuleItem());
+            verify(customItemsModule).getItemById("foobar");
+            verify(itemGenModule, never()).getItemById("foobar");
+        }
+    }
+
+    @Test
+    void getItem_itemStackWithoutStoredModule_fallsBackToBareIdLookup() {
+        ItemStack itemStack = mock(ItemStack.class);
+
+        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
+        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
+
+        try (MockedStatic<ItemStats> itemStats = mockStatic(ItemStats.class)) {
+            itemStats.when(() -> ItemStats.getId(itemStack)).thenReturn("foobar");
+            itemStats.when(() -> ItemStats.getModule(itemStack)).thenReturn(null);
+
+            DivinityProvider.DivinityItemType item = provider.getItem(itemStack);
+
+            assertNotNull(item);
+            assertEquals(generatorItem, item.getModuleItem());
+        }
+    }
+
+    @Test
+    void getItem_ambiguousBareId_returnsNull() {
+        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
+        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
+
+        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
+        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
+
+        DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_foobar");
+
+        assertNull(item);
+    }
+
+    @Test
+    void getItem_ambiguousId_stillResolvableWithModulePrefix() {
+        ItemGeneratorManager.GeneratorItem generatorItem = mock(ItemGeneratorManager.GeneratorItem.class);
+        doReturn(generatorItem).when(itemGenModule).getItemById("foobar");
+
+        CustomItemsManager.CustomItem codexItem = mock(CustomItemsManager.CustomItem.class);
+        doReturn(codexItem).when(customItemsModule).getItemById("foobar");
+
+        DivinityProvider.DivinityItemType item = provider.getItem("DIVINITY_custom_items:foobar");
+
+        assertNotNull(item);
+        assertEquals(codexItem, item.getModuleItem());
     }
 }


### PR DESCRIPTION
Split out of #320 (piece 3/12, independent).

`DivinityProvider` previously namespaced item IDs by their owning module (e.g. `custom_items:foobar`) when resolving items by `ItemStack` or ID string. Since item IDs are unique across modules in practice, this indirection added complexity without a real need; `getItem()`/`getID()` now resolve by plain item ID where possible, while still supporting the module-prefixed form for disambiguation.

## Ambiguous bare-id resolution
Bare-id lookup (no `module:` prefix) now checks *all* modules for a match:
- Exactly one module has the id → resolves as before.
- Two or more modules share the id → logs an error naming the conflicting modules and returns `null` instead of silently picking whichever module happened to iterate first. Callers can disambiguate with the `module:id` form.

`getItem(ItemStack)` again prefers the item's stored module when present, so items resolve directly against their own module and skip the ambiguity check entirely — this restores the pre-simplification behavior for the common case while still allowing bare-id lookups elsewhere (e.g. config-driven references).

`DivinityItemType.getID()` mirrors the same ambiguity check: it returns the plain id when it's unique across modules, and falls back to the `module:id` form when two or more modules share it, so the returned id is always actually resolvable via `getItem()`.

## Backward compatibility
`getItem(String)` already parses the legacy `"module:id"` namespaced form unchanged, so any stored/external reference captured via the old `getID()` format still resolves correctly. `isCustomItemOfId` falls back to the module+split check when plain-ID equality doesn't match, so legacy namespaced callers still work instead of always returning false.

## Tests
Restored the `getItem_itemStackUsesStoredModule` regression test dropped in the initial simplification, and added coverage for: falling back to bare-id lookup when no module is stored, ambiguous bare ids returning `null`, ambiguous ids still resolving via explicit `module:id`, and `getID()` returning the plain vs. module-prefixed form depending on uniqueness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)