### PR TITLE
Fix dead test dependency repository URL

### DIFF
--- a/src/test/java/studio/magemonkey/divinity/testutil/DependencyResolver.java
+++ b/src/test/java/studio/magemonkey/divinity/testutil/DependencyResolver.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class DependencyResolver {
     private static List<String> repositories =
-            List.of("https://repo.travja.dev/snapshots/", "https://repo1.maven.org/maven2");
+            List.of("https://central.sonatype.com/repository/maven-snapshots/", "https://repo1.maven.org/maven2");
 
     public static File resolve(String dependency) throws FileNotFoundException {
         log.info("Attempting to resolve dependency " + dependency);


### PR DESCRIPTION
Split out of #320 (piece 4/12, independent).

`repo.travja.dev` is no longer reachable; points the test dependency resolver at central.sonatype.com's snapshot repository instead.

## Backward compatibility
None applicable — test-only file, no runtime/user-facing surface.