### PR TITLE
Add roman-numeral toggle for enchantment lore, hide-flags groundwork

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -49,7 +49,6 @@ public class EngineCfg {
     public static boolean ATTRIBUTES_HIDE_FLAGS;
 
     public static boolean     ATTRIBUTES_DURABILITY_BREAK_ITEMS;
-    public static boolean     ATTRIBUTES_HIDE_FLAGS;
     public static boolean     ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS;
     public static Set<String> ATTRIBUTES_DURABILITY_REDUCE_FOR_SKILL_API;
 

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -48,6 +48,7 @@ public class EngineCfg {
     public static boolean ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS;
 
     public static boolean     ATTRIBUTES_DURABILITY_BREAK_ITEMS;
+    public static boolean     ATTRIBUTES_HIDE_FLAGS;
     public static boolean     ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS;
     public static Set<String> ATTRIBUTES_DURABILITY_REDUCE_FOR_SKILL_API;
 
@@ -108,8 +109,9 @@ public class EngineCfg {
     public static String LORE_STYLE_REQ_ITEM_MODULE_FORMAT_SEPAR;
     public static String LORE_STYLE_REQ_ITEM_MODULE_FORMAT_COLOR;
 
-    public static String LORE_STYLE_ENCHANTMENTS_FORMAT_MAIN;
-    public static int    LORE_STYLE_ENCHANTMENTS_FORMAT_MAX_ROMAN;
+    public static String  LORE_STYLE_ENCHANTMENTS_FORMAT_MAIN;
+    public static int     LORE_STYLE_ENCHANTMENTS_FORMAT_MAX_ROMAN;
+    public static boolean LORE_STYLE_ENCHANTMENTS_ROMAN_SYSTEM;
 
     public static String LORE_STYLE_FABLED_ATTRIBUTE_FORMAT;
 
@@ -177,6 +179,7 @@ public class EngineCfg {
         EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS = cfg.getBoolean(path + "effective-for-mobs");
         EngineCfg.ATTRIBUTES_EFFECTIVE_IN_OFFHAND = cfg.getBoolean(path + "effective-in-offhand");
         EngineCfg.ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS = cfg.getBoolean(path + "allow-hold-items-you-cant-use");
+        EngineCfg.ATTRIBUTES_HIDE_FLAGS = cfg.getBoolean(path + "hide-flags");
 
         path = "attributes.durability.";
         EngineCfg.ATTRIBUTES_DURABILITY_BREAK_ITEMS = cfg.getBoolean(path + "break-items-on-zero");
@@ -415,9 +418,11 @@ public class EngineCfg {
         path = "lore.stats.style.enchantments.";
         cfg.addMissing(path + "format.main", "&c▸ %name% %value%");
         cfg.addMissing(path + "format.max-roman", 10);
+        cfg.addMissing(path + "roman-system", true);
         EngineCfg.LORE_STYLE_ENCHANTMENTS_FORMAT_MAIN =
                 StringUT.color(cfg.getString(path + "format.main", "&c▸ %name% %value%"));
         EngineCfg.LORE_STYLE_ENCHANTMENTS_FORMAT_MAX_ROMAN = cfg.getInt(path + "format.max-roman", 10);
+        EngineCfg.LORE_STYLE_ENCHANTMENTS_ROMAN_SYSTEM = cfg.getBoolean(path + "roman-system", true);
 
         path = "lore.stats.style.fabled-attribute-format";
         cfg.addMissing(path, "&7%attrPre%&3%name%&7%attrPost%");

--- a/src/main/java/studio/magemonkey/divinity/utils/LoreUT.java
+++ b/src/main/java/studio/magemonkey/divinity/utils/LoreUT.java
@@ -127,8 +127,10 @@ public class LoreUT {
             String value = EngineCfg.LORE_STYLE_ENCHANTMENTS_FORMAT_MAIN
                     .replace("%name%", plugin.lang().getEnchantment(e))
                     .replace("%value%",
-                            level > EngineCfg.LORE_STYLE_ENCHANTMENTS_FORMAT_MAX_ROMAN ? String.valueOf(level)
-                                    : NumberUT.toRoman(level));
+                            !EngineCfg.LORE_STYLE_ENCHANTMENTS_ROMAN_SYSTEM ? String.valueOf(level)
+                                    : (level > EngineCfg.LORE_STYLE_ENCHANTMENTS_FORMAT_MAX_ROMAN
+                                            ? String.valueOf(level)
+                                            : NumberUT.toRoman(level)));
             lore.add(pos, value);
         }
         meta.setLore(lore);

--- a/src/main/resources/engine.yml
+++ b/src/main/resources/engine.yml
@@ -63,6 +63,8 @@ attributes:
   # When enabled, allows to hold in hand items with requirements that player don't meet.
   # Even when this is 'true', item attributes won't be applied to a player until he meet the requirements.
   allow-hold-items-you-cant-use: false
+  # When enabled, hides attributes and enchantments by default on all custom items.
+  hide-flags: true
 
 combat:
   # Whether to use the old combat formula for calculating defenses
@@ -226,6 +228,7 @@ lore:
             format:
               main: '&c▸ %name%: %value%'
       enchantments:
+        roman-system: true  # true = roman numerals (I, II, III...), false = arabic numbers (1, 2, 3...)
         format:
           main: '&c▸ %name% %value%'
           max-roman: 10


### PR DESCRIPTION
Split out of #320 (piece 8/12, independent).

`lore.stats.style.enchantments.roman-system` lets servers switch enchantment level display between roman numerals and plain arabic numbers (previously roman numerals were hardcoded below the `max-roman` threshold).

Also adds `attributes.hide-flags` to `engine.yml`/`EngineCfg`, intended to toggle whether attributes/enchantments are hidden by default on custom items.

**Note for reviewers:** `ATTRIBUTES_HIDE_FLAGS` is only declared and loaded here — nothing in this change consumes it yet, so it's a no-op groundwork addition pending a follow-up that wires it up.

## Backward compatibility
Already safe by default — `roman-system` defaults to `true`, which is byte-for-byte the previous hardcoded behavior (roman numerals below `max-roman`). No migration needed.